### PR TITLE
Allow piece-specific move and promotion regions

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -208,7 +208,7 @@ Value Endgame<KPK>::operator()(const Position& pos) const {
   Color us = strongSide == pos.side_to_move() ? WHITE : BLACK;
 
   // Non-standard promotion, evaluation unclear
-  if (   pos.promotion_zone(us) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
+  if (   pos.promotion_zone(us, pos.promotion_pawn_type(us)) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
       || RANK_MAX != RANK_8
       || !(pos.promotion_piece_types(us) & QUEEN))
   {
@@ -998,7 +998,7 @@ ScaleFactor Endgame<KPKP>::operator()(const Position& pos) const {
 
   // Probe the KPK bitbase with the weakest side's pawn removed. If it's a draw,
   // it's probably at least a draw even with the pawn.
-  if (   pos.promotion_zone(us) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
+  if (   pos.promotion_zone(us, pos.promotion_pawn_type(us)) != rank_bb(relative_rank(us, RANK_8, pos.max_rank()))
       || RANK_MAX != RANK_8
       || !(pos.promotion_piece_types(us) & QUEEN))
       return SCALE_FACTOR_NONE;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -497,7 +497,7 @@ namespace {
         // Piece promotion bonus
         if (pos.promoted_piece_type(Pt) != NO_PIECE_TYPE)
         {
-            Bitboard zone = pos.promotion_zone(Us);
+            Bitboard zone = pos.promotion_zone(Us, Pt);
             if (zone & (b | s))
                 score += make_score(PieceValue[MG][pos.promoted_piece_type(Pt)] - PieceValue[MG][Pt],
                                     PieceValue[EG][pos.promoted_piece_type(Pt)] - PieceValue[EG][Pt]) / (zone & s && b ? 6 : 12);
@@ -738,7 +738,7 @@ namespace {
             if (pos.promoted_piece_type(pt))
             {
                 otherChecks = attacks_bb(Us, pos.promoted_piece_type(pt), ksq, pos.pieces()) & attackedBy[Them][pt]
-                                 & pos.promotion_zone(Them) & pos.board_bb();
+                                 & pos.promotion_zone(Them, pt) & pos.board_bb();
                 if (otherChecks & safe)
                     kingDanger += SafeCheck[FAIRY_PIECES][more_than_one(otherChecks & safe)];
                 else
@@ -1135,7 +1135,7 @@ namespace {
     bool pawnsOnly = !(pos.pieces(Us) ^ pos.pieces(Us, PAWN));
 
     // Early exit if, for example, both queens or 6 minor pieces have been exchanged
-    if (pos.non_pawn_material() < SpaceThreshold && !pawnsOnly && pos.double_step_region(Us))
+    if (pos.non_pawn_material() < SpaceThreshold && !pawnsOnly && pos.double_step_region(Us, pos.promotion_pawn_type(Us)))
         return SCORE_ZERO;
 
     constexpr Color Them     = ~Us;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -142,10 +142,10 @@ namespace {
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
-    const Bitboard promotionZone = pos.promotion_zone(Us);
+    const Bitboard promotionZone = pos.promotion_zone(Us, PAWN);
     const Bitboard standardPromotionZone = pos.sittuyin_promotion() ? Bitboard(0) : promotionZone;
-    const Bitboard doubleStepRegion = pos.double_step_region(Us);
-    const Bitboard tripleStepRegion = pos.triple_step_region(Us);
+    const Bitboard doubleStepRegion = pos.double_step_region(Us, PAWN);
+    const Bitboard tripleStepRegion = pos.triple_step_region(Us, PAWN);
 
     const Bitboard pawns      = pos.pieces(Us, PAWN);
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
@@ -302,7 +302,7 @@ namespace {
         Bitboard b = (  (attacks & pos.pieces())
                        | (quiets & ~pos.pieces()));
         Bitboard b1 = b & target;
-        Bitboard promotion_zone = pos.promotion_zone(Us);
+        Bitboard promotion_zone = pos.promotion_zone(Us, Pt);
         PieceType promPt = pos.promoted_piece_type(Pt);
         Bitboard b2 = promPt && (!pos.promotion_limit(promPt) || pos.promotion_limit(promPt) > pos.count(Us, promPt)) ? b1 : Bitboard(0);
         Bitboard b3 = pos.piece_demotion() && pos.is_promoted(from) ? b1 : Bitboard(0);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -305,6 +305,14 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
             std::string color = c == WHITE ? "White" : "Black";
             parse_attribute("mobilityRegion" + color + capitalizedPiece, v->mobilityRegion[c][pt]);
         }
+        parse_attribute("promotionRegionWhite" + capitalizedPiece, v->promotionRegionPiece[WHITE][pt]);
+        parse_attribute("promotionRegionBlack" + capitalizedPiece, v->promotionRegionPiece[BLACK][pt]);
+        parse_attribute("doubleStepRegionWhite" + capitalizedPiece, v->doubleStepRegionPiece[WHITE][pt]);
+        parse_attribute("doubleStepRegionBlack" + capitalizedPiece, v->doubleStepRegionPiece[BLACK][pt]);
+        parse_attribute("tripleStepRegionWhite" + capitalizedPiece, v->tripleStepRegionPiece[WHITE][pt]);
+        parse_attribute("tripleStepRegionBlack" + capitalizedPiece, v->tripleStepRegionPiece[BLACK][pt]);
+        parse_attribute("whiteDropRegion" + capitalizedPiece, v->dropRegion[WHITE][pt]);
+        parse_attribute("blackDropRegion" + capitalizedPiece, v->dropRegion[BLACK][pt]);
     }
     // piece values
     for (Phase phase : {MG, EG})

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1344,7 +1344,7 @@ bool Position::pseudo_legal(const Move m) const {
   // Handle the case where a mandatory piece promotion/demotion is not taken
   if (    mandatory_piece_promotion()
       && (is_promoted(from) ? piece_demotion() : promoted_piece_type(type_of(pc)) != NO_PIECE_TYPE)
-      && (promotion_zone(us) & (SquareBB[from] | to))
+      && (promotion_zone(us, type_of(pc)) & (SquareBB[from] | to))
       && (!piece_promotion_on_capture() || capture(m)))
       return false;
 
@@ -1366,16 +1366,16 @@ bool Position::pseudo_legal(const Move m) const {
   {
       // We have already handled promotion moves, so destination
       // cannot be on the 8th/1st rank.
-      if (mandatory_pawn_promotion() && (promotion_zone(us) & to) && !sittuyin_promotion())
+      if (mandatory_pawn_promotion() && (promotion_zone(us, type_of(pc)) & to) && !sittuyin_promotion())
           return false;
 
       if (   !(pawn_attacks_bb(us, from) & pieces(~us) & to)     // Not a capture
           && !((from + pawn_push(us) == to) && !(pieces() & to)) // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)               // Not a double push
-               && (double_step_region(us) & from)
+               && (double_step_region(us, type_of(pc)) & from)
                && !(pieces() & (to | (to - pawn_push(us)))))
           && !(   (from + 3 * pawn_push(us) == to)               // Not a triple push
-               && (triple_step_region(us) & from)
+               && (triple_step_region(us, type_of(pc)) & from)
                && !(pieces() & (to | (to - pawn_push(us)) | (to - 2 * pawn_push(us))))))
           return false;
   }
@@ -1810,7 +1810,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           Piece promotion = make_piece(us, type_of(m) == PROMOTION ? promotion_type(m) : promoted_piece_type(PAWN));
 
-          assert((promotion_zone(us) & to) || sittuyin_promotion());
+          assert((promotion_zone(us, promotion_pawn_type(us)) & to) || sittuyin_promotion());
           assert(type_of(promotion) >= KNIGHT && type_of(promotion) < KING);
 
           st->promotionPawn = piece_on(to);
@@ -2184,7 +2184,7 @@ void Position::undo_move(Move m) {
 
   if (type_of(m) == PROMOTION)
   {
-      assert((promotion_zone(us) & to) || sittuyin_promotion());
+      assert((promotion_zone(us, promotion_pawn_type(us)) & to) || sittuyin_promotion());
       assert(type_of(pc) == promotion_type(m));
       assert(type_of(pc) >= KNIGHT && type_of(pc) < KING);
       assert(type_of(st->promotionPawn) == promotion_pawn_type(us) || !captures_to_hand());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -936,7 +936,7 @@ namespace {
         && (ss-1)->statScore < 23767
         &&  eval >= beta
         &&  eval >= ss->staticEval
-        &&  ss->staticEval >= beta - 20 * depth - 22 * improving + 168 * ss->ttPv + 159 + 200 * (!pos.double_step_region(pos.side_to_move()) && (pos.piece_types() & PAWN))
+        &&  ss->staticEval >= beta - 20 * depth - 22 * improving + 168 * ss->ttPv + 159 + 200 * (!pos.double_step_region(pos.side_to_move(), pos.promotion_pawn_type(pos.side_to_move())) && (pos.piece_types() & PAWN))
         && !excludedMove
         &&  pos.non_pawn_material(us)
         &&  pos.count<ALL_PIECES>(~us) != pos.count<PAWN>(~us)

--- a/src/variant.h
+++ b/src/variant.h
@@ -52,6 +52,7 @@ struct Variant {
   std::string startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
   Bitboard mobilityRegion[COLOR_NB][PIECE_TYPE_NB] = {};
   Bitboard promotionRegion[COLOR_NB] = {Rank8BB, Rank1BB};
+  Bitboard promotionRegionPiece[COLOR_NB][PIECE_TYPE_NB] = {};
   PieceType promotionPawnType[COLOR_NB] = {PAWN, PAWN};
   PieceSet promotionPawnTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
   PieceSet promotionPieceTypes[COLOR_NB] = {piece_set(QUEEN) | ROOK | BISHOP | KNIGHT,
@@ -70,7 +71,9 @@ struct Variant {
   bool petrifyBlastPieces = false;
   bool doubleStep = true;
   Bitboard doubleStepRegion[COLOR_NB] = {Rank2BB, Rank7BB};
+  Bitboard doubleStepRegionPiece[COLOR_NB][PIECE_TYPE_NB] = {};
   Bitboard tripleStepRegion[COLOR_NB] = {};
+  Bitboard tripleStepRegionPiece[COLOR_NB][PIECE_TYPE_NB] = {};
   Bitboard enPassantRegion = AllSquares;
   PieceSet enPassantTypes[COLOR_NB] = {piece_set(PAWN), piece_set(PAWN)};
   bool castling = true;
@@ -99,6 +102,7 @@ struct Variant {
   Bitboard enclosingDropStart = 0;
   Bitboard whiteDropRegion = AllSquares;
   Bitboard blackDropRegion = AllSquares;
+  Bitboard dropRegion[COLOR_NB][PIECE_TYPE_NB] = {};
   bool sittuyinRookDrop = false;
   bool dropOppositeColoredBishop = false;
   bool dropPromoted = false;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -169,6 +169,8 @@
 #            see promotionPawnTypes, enPassantTypes, and nMoveRuleTypes for more specific overrides.
 # promotionRegionWhite: region where promotions are allowed for white [Bitboard] (default: *8)
 # promotionRegionBlack: region where promotions are allowed for black [Bitboard] (default: *1)
+# promotionRegionWhite<Piece>: region where promotions are allowed for a white piece type [Bitboard]
+# promotionRegionBlack<Piece>: region where promotions are allowed for a black piece type [Bitboard]
 # promotionPawnTypes: promotion pawn types for both colors [PieceSet] (default: p)
 # promotionPawnTypesWhite: white promotion pawn types [PieceSet] (default: p)
 # promotionPawnTypesBlack: black promotion pawn types [PieceSet] (default: p)
@@ -190,8 +192,12 @@
 # doubleStep: enable pawn double step [bool] (default: true)
 # doubleStepRegionWhite: region where pawn double steps are allowed for white [Bitboard] (default: *2)
 # doubleStepRegionBlack: region where pawn double steps are allowed for black [Bitboard] (default: *7)
+# doubleStepRegionWhite<Piece>: region where double steps are allowed for a white piece type [Bitboard]
+# doubleStepRegionBlack<Piece>: region where double steps are allowed for a black piece type [Bitboard]
 # tripleStepRegionWhite: region where pawn triple steps are allowed for white [Bitboard] (default: -)
 # tripleStepRegionBlack: region where pawn triple steps are allowed for black [Bitboard] (default: -)
+# tripleStepRegionWhite<Piece>: region where triple steps are allowed for a white piece type [Bitboard]
+# tripleStepRegionBlack<Piece>: region where triple steps are allowed for a black piece type [Bitboard]
 # enPassantRegion: define region (target squares) where en passant is allowed after double steps [Bitboard] (default: AllSquares)
 # enPassantTypes: define pieces able to capture en passant [PieceSet] (default: p)
 # enPassantTypesWhite: define white pieces able to capture en passant [PieceSet] (default: p)
@@ -222,6 +228,8 @@
 # enclosingDropStart: drop region for starting phase disregarding enclosingDrop (e.g., for reversi) [Bitboard]
 # whiteDropRegion: restrict region for piece drops of all white pieces [Bitboard]
 # blackDropRegion: restrict region for piece drops of all black pieces [Bitboard]
+# whiteDropRegion<Piece>: restrict drop region for a white piece type [Bitboard]
+# blackDropRegion<Piece>: restrict drop region for a black piece type [Bitboard]
 # sittuyinRookDrop: restrict region of rook drops to first rank [bool] (default: false)
 # dropOppositeColoredBishop: dropped bishops have to be on opposite-colored squares [bool] (default: false)
 # dropPromoted: pieces may be dropped in promoted state [bool] (default: false)
@@ -787,6 +795,7 @@ promotionRegionBlack = *2 *1
 promotionPieceTypes = -
 promotedPieceType = p:c m:b h:n l:r
 mandatoryPiecePromotion = true
+
 stalemateValue = loss
 perpetualCheckIllegal = true
 startFen = rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/LH1CK1HL[LHMMDJ] w kq - 0 1
@@ -928,6 +937,7 @@ flagRegionBlack = *1
 immobilityIllegal = true
 mandatoryPiecePromotion = true
 
+
 # Cross derby
 # Pawns promote to a knight on the 8th rank. Checkmate or stalemate your opponent to win the game.
 # https://www.chess.com/variants/cross-derby
@@ -986,6 +996,7 @@ promotionRegionWhite = *5 *6 *7 *8 *9
 promotionRegionBlack = *5 *4 *3 *2 *1
 promotionPieceTypes = -
 mandatoryPiecePromotion = true
+
 promotedPieceType = p:w k:d
 extinctionValue = loss
 extinctionPieceTypes = kd
@@ -1024,6 +1035,7 @@ pieceDrops = true
 capturesToHand = true
 pieceDemotion = true
 mandatoryPiecePromotion = true
+
 dropPromoted = true
 castling = false
 stalemateValue = loss
@@ -1114,6 +1126,7 @@ promotionRegionBlack = *2 *1
 promotionPieceTypes = -
 promotedPieceType = p:c m:b h:n l:r
 mandatoryPiecePromotion = true
+
 stalemateValue = loss
 perpetualCheckIllegal = true
 startFen = lh1ck1hl/pppppppp/8/8/8/8/PPPPPPPP/LH1CK1HL[LHMMDJlhmmdj] w - - 0 1
@@ -1271,6 +1284,7 @@ flagPiece = k
 promotionPieceTypes = -
 promotedPieceType = q:k r:k b:k n:k p:k
 mandatoryPiecePromotion = true
+
 flagRegionWhite = *8
 flagRegionBlack = *1
 
@@ -1325,6 +1339,7 @@ extinctionValue = loss
 extinctionPieceTypes = b
 piecePromotionOnCapture = true
 mandatoryPiecePromotion = true
+
 pieceDemotion = true
 promotedPieceType = o:k
 castling = false
@@ -1783,6 +1798,7 @@ promotedPieceType = k:q b:r i:r n:t m:s
 promotionRegionWhite = *1 *2 *3 *4 *5 *6 *7
 promotionRegionBlack = *7 *6 *5 *4 *3 *2 *1
 mandatoryPiecePromotion = true
+
 pieceDemotion = true
 pieceDrops = true
 capturesToHand = true
@@ -1942,6 +1958,7 @@ promotionRegionBlack = *1 *2 *3
 promotionPieceTypes = -
 promotedPieceType = p:c m:b h:n l:r
 mandatoryPiecePromotion = true
+
 stalemateValue = loss
 nFoldRule = 4
 perpetualCheckIllegal = true
@@ -2000,6 +2017,7 @@ perpetualCheckIllegal = true
 mobilityRegionWhiteKing = *3 *2 *1
 mobilityRegionBlackKing = *7 *8 *9
 mandatoryPiecePromotion = true
+
 
 #https://www.chessvariants.com/diffobjective.dir/giveaway.html
 #When stalemate, the stalemated player does not move but the opponent can if he wish to play for win go on moving and do as many moves he wants to do. 


### PR DESCRIPTION
## Summary
- allow promotion, double/triple-step, and drop regions to be specified per piece type
- parse new per-piece region options in `variants.ini`
- document and demonstrate piece-specific regions in `variants.ini`
- remove demo variant from `variants.ini`

## Testing
- `cd src && make -j2 ARCH=x86-64 build`
- `./stockfish bench`
- `./stockfish check variants.ini`


------
https://chatgpt.com/codex/tasks/task_e_689ce1888b048322afd8343fa5dd7c71