### PR TITLE
Add support for dead pieces

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -606,7 +606,7 @@ inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard,
     {
         if (c == ' ' || c == '[')
             break;
-        if (c == '*')
+        if (c == '*' || c == '^')
             ++fileIdx;
         else if (isdigit(c))
         {
@@ -956,7 +956,7 @@ inline Validation check_digit_field(const std::string& field) {
 }
 
 inline std::string get_valid_special_chars(const Variant* v) {
-    std::string validSpecialCharactersFirstField = "/*";
+    std::string validSpecialCharactersFirstField = "/*^";
     // Whether or not '-', '+', '~', '[', ']' are valid depends on the variant being played.
     if (v->shogiStylePromotions)
         validSpecialCharactersFirstField += '+';

--- a/test.py
+++ b/test.py
@@ -335,6 +335,23 @@ class TestPyffish(unittest.TestCase):
         result = sf.legal_moves("xiangqi", XIANGQI, ["h3h10"])
         self.assertIn("i10h10", result)
 
+        # Capturing a dead piece is legal and treated as a capture
+        fen = "k7/8/8/8/8/8/4^3/4K3 w - - 0 1"
+        result = sf.legal_moves("chess", fen, [])
+        self.assertIn("e1e2", result)
+        self.assertTrue(sf.is_capture("chess", fen, [], "e1e2"))
+        new_fen = sf.get_fen("chess", fen, ["e1e2"])
+        self.assertNotIn("^", new_fen.split()[0])
+
+        # Sliders cannot move through dead pieces
+        fen = "4k3/8/8/r7/8/^7/8/Q6K w - - 0 1"
+        result = sf.legal_moves("chess", fen, [])
+        self.assertIn("a1a3", result)
+        self.assertNotIn("a1a5", result)
+        self.assertTrue(sf.is_capture("chess", fen, [], "a1a3"))
+        result = sf.legal_moves("chess", fen, ["a1a3", "e8d7"])
+        self.assertIn("a3a5", result)
+
         result = sf.legal_moves("xiangqi", XIANGQI, ["h3h10"])
         self.assertIn("i10h10", result)
 


### PR DESCRIPTION
## Summary
- parse dead pieces (^) from FEN
- track dead squares in state and hash
- include dead squares when generating moves
- allow capturing dead pieces and treat them as blockers
- extend FEN validation to accept ^
- cover dead-piece behavior in tests

## Testing
- `make -j2 build`
- `python3 setup.py build_ext --inplace`
- `python3 test.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce1a5785083228ac754d649def033