### PR TITLE
Add iron pieces rule and demo variant

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -419,6 +419,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("blastOnCapture", v->blastOnCapture);
     parse_attribute("blastImmuneTypes", v->blastImmuneTypes, v->pieceToChar);
     parse_attribute("mutuallyImmuneTypes", v->mutuallyImmuneTypes, v->pieceToChar);
+    parse_attribute("ironPieceTypes", v->ironPieceTypes, v->pieceToChar);
     parse_attribute("petrifyOnCaptureTypes", v->petrifyOnCaptureTypes, v->pieceToChar);
     parse_attribute("petrifyBlastPieces", v->petrifyBlastPieces);
     parse_attribute("doubleStep", v->doubleStep);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1205,6 +1205,14 @@ bool Position::legal(Move m) const {
   )
   return false;
 
+  // Iron pieces: any attempt to capture them is illegal (but they can capture normally)
+  if (capture(m)) {
+      Square csq = (type_of(m) == EN_PASSANT) ? capture_square(to) : to;
+      Piece  cpc = piece_on(csq);
+      if (cpc != NO_PIECE && (iron_piece_types() & type_of(cpc)))
+          return false;
+  }
+
   // En passant captures are a tricky special case. Because they are rather
   // uncommon, we do it simply by testing whether the king is attacked after
   // the move is made.

--- a/src/position.h
+++ b/src/position.h
@@ -142,6 +142,7 @@ public:
   bool blast_on_capture() const;
   PieceSet blast_immune_types() const;
   PieceSet mutually_immune_types() const;
+  PieceSet iron_piece_types() const;
   EndgameEval endgame_eval() const;
   Bitboard double_step_region(Color c) const;
   Bitboard triple_step_region(Color c) const;
@@ -516,6 +517,11 @@ inline PieceSet Position::blast_immune_types() const {
 inline PieceSet Position::mutually_immune_types() const {
   assert(var != nullptr);
   return var->mutuallyImmuneTypes;
+}
+
+inline PieceSet Position::iron_piece_types() const {
+  assert(var != nullptr);
+  return var->ironPieceTypes;
 }
 
 inline EndgameEval Position::endgame_eval() const {

--- a/src/variant.h
+++ b/src/variant.h
@@ -66,6 +66,8 @@ struct Variant {
   bool blastOnCapture = false;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
+  // Iron pieces: attempts to capture these piece types are illegal
+  PieceSet ironPieceTypes = NO_PIECE_SET;
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;
   bool petrifyBlastPieces = false;
   bool doubleStep = true;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -185,6 +185,7 @@
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
+# ironPieceTypes: pieces that are uncapturable (attempting to capture them is illegal) [PieceSet] (default: none)
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
 # doubleStep: enable pawn double step [bool] (default: true)
@@ -928,7 +929,6 @@ flagRegionWhite = *9
 flagRegionBlack = *1
 immobilityIllegal = true
 mandatoryPiecePromotion = true
-
 # Cross derby
 # Pawns promote to a knight on the 8th rank. Checkmate or stalemate your opponent to win the game.
 # https://www.chess.com/variants/cross-derby
@@ -2045,3 +2045,7 @@ flagRegionWhite = *10
 flagRegionBlack = *1
 immobilityIllegal = true
 mandatoryPiecePromotion = true
+
+# Iron pieces demo: pawns are uncapturable; everything else behaves normally.
+[iron-pawns:chess]
+ironPieceTypes = p

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@
 import faulthandler
 import unittest
 import pyffish as sf
+import io, os
 
 faulthandler.enable()
 
@@ -21,6 +22,33 @@ GRANDHOUSE = "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R[] 
 XIANGQI = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w - - 0 1"
 SHOGUN = "rnb+fkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB+FKBNR[] w KQkq - 0 1"
 JANGGI = "rnba1abnr/4k4/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/4K4/RNBA1ABNR w - - 0 1"
+
+
+class TestIronPieces(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Load runtime variant config (includes our [iron-pawns] entry)
+        ini_path = os.path.join(os.path.dirname(__file__), "src", "variants.ini")
+        with io.open(ini_path, "r", encoding="utf8") as fh:
+            sf.load_variant_config(fh.read())
+
+    def test_capturing_iron_pawn_is_illegal(self):
+        # White bishop would normally capture the pawn on e5, but pawns are iron here.
+        fen = "4k3/8/8/4p3/8/6B1/8/4K3 w - - 0 1"
+        moves = sf.legal_moves("iron-pawns", fen, [])
+        self.assertNotIn("g3e5", moves)
+
+    def test_iron_pawn_can_capture_normally(self):
+        # Iron pawns are only uncapturable; they can still capture other pieces.
+        fen = "4k3/8/5n2/4P3/8/8/8/4K3 w - - 0 1"
+        moves = sf.legal_moves("iron-pawns", fen, [])
+        self.assertIn("e5f6", moves)
+
+    def test_en_passant_against_iron_pawn_is_illegal(self):
+        # EP square d6 indicates last move ...d7-d5; EP capture e5xd6 would hit an iron pawn.
+        fen = "4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1"
+        moves = sf.legal_moves("iron-pawns", fen, [])
+        self.assertNotIn("e5d6", moves)
 
 
 ini_text = """


### PR DESCRIPTION
## Summary
- add `ironPieceTypes` to variant rules and expose via `Position`
- reject captures of iron pieces and parse `ironPieceTypes` from variant configs
- document new option, add `iron-pawns` demo variant, and test iron piece capture rules

## Testing
- `make -j2 ARCH=x86-64 build`
- `./stockfish bench`
- `./stockfish check variants.ini`
- `python3 test.py TestIronPieces`


------
https://chatgpt.com/codex/tasks/task_e_68a1e40bbb088322b276d5bf137ef655