### PR TITLE
Add self-capture variant support and tests

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -142,6 +142,9 @@ namespace {
     constexpr Direction UpRight  = (Us == WHITE ? NORTH_EAST : SOUTH_WEST);
     constexpr Direction UpLeft   = (Us == WHITE ? NORTH_WEST : SOUTH_EAST);
 
+    const bool allowFriendlyCaptures = pos.self_capture()
+                                    && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
+
     const Bitboard promotionZone = pos.promotion_zone(Us);
     const Bitboard standardPromotionZone = pos.sittuyin_promotion() ? Bitboard(0) : promotionZone;
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
@@ -149,7 +152,7 @@ namespace {
 
     const Bitboard pawns      = pos.pieces(Us, PAWN);
     const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
-    const Bitboard capturable = pos.board_bb(Us, PAWN) &  pos.pieces(Them);
+    const Bitboard capturable = pos.board_bb(Us, PAWN) & (allowFriendlyCaptures ? pos.pieces() : pos.pieces(Them));
 
     target = Type == EVASIONS ? target : AllSquares;
 
@@ -287,11 +290,14 @@ namespace {
 
 
   template<Color Us, GenType Type>
-  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, PieceType Pt, Bitboard target) {
+  ExtMove* generate_moves(const Position& pos, ExtMove* moveList, PieceType Pt, Bitboard target, Bitboard captureTarget) {
 
     assert(Pt != KING && Pt != PAWN);
 
     Bitboard bb = pos.pieces(Us, Pt);
+
+    const bool allowFriendlyCaptures = pos.self_capture()
+                                    && (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS);
 
     while (bb)
     {
@@ -299,14 +305,20 @@ namespace {
 
         Bitboard attacks = pos.attacks_from(Us, Pt, from);
         Bitboard quiets = pos.moves_from(Us, Pt, from);
-        Bitboard b = (  (attacks & pos.pieces())
-                       | (quiets & ~pos.pieces()));
-        Bitboard b1 = b & target;
+        Bitboard captureSquares = (attacks & pos.pieces()) & captureTarget;
+        Bitboard quietSquares   = (quiets & ~pos.pieces()) & target;
+        Bitboard b = captureSquares | quietSquares;
+        Bitboard b1 = b;
         Bitboard promotion_zone = pos.promotion_zone(Us);
         PieceType promPt = pos.promoted_piece_type(Pt);
         Bitboard b2 = promPt && (!pos.promotion_limit(promPt) || pos.promotion_limit(promPt) > pos.count(Us, promPt)) ? b1 : Bitboard(0);
         Bitboard b3 = pos.piece_demotion() && pos.is_promoted(from) ? b1 : Bitboard(0);
-        Bitboard pawnPromotions = (pos.promotion_pawn_types(Us) & Pt) ? (b & (Type == EVASIONS ? target : ~pos.pieces(Us)) & promotion_zone) : Bitboard(0);
+        Bitboard pawnPromotions = (pos.promotion_pawn_types(Us) & Pt)
+                                ? (b & (Type == EVASIONS ? target
+                                                         : (~pos.pieces(Us)
+                                                            | (allowFriendlyCaptures ? pos.pieces(Us) : Bitboard(0))))
+                                     & promotion_zone)
+                                : Bitboard(0);
         Bitboard epSquares = (pos.en_passant_types(Us) & Pt) ? (attacks & ~quiets & pos.ep_squares() & ~pos.pieces()) : Bitboard(0);
 
         // target squares considering pawn promotions
@@ -380,6 +392,7 @@ namespace {
     constexpr bool Checks = Type == QUIET_CHECKS; // Reduce template instantiations
     const Square ksq = pos.count<KING>(Us) ? pos.square<KING>(Us) : SQ_NONE;
     Bitboard target;
+    Bitboard captureTarget = Type == EVASIONS ? ~pos.pieces(Us) : Bitboard(0);
 
     // Skip generating non-king moves when in double check
     if (Type != EVASIONS || !more_than_one(pos.checkers() & ~pos.non_sliding_riders()))
@@ -402,9 +415,13 @@ namespace {
         // Remove inaccessible squares (outside board + wall squares)
         target &= pos.board_bb();
 
+        captureTarget = target;
+        if (pos.self_capture() && (Type == NON_EVASIONS || Type == CAPTURES))
+            captureTarget |= pos.pieces(Us);
+
         moveList = generate_pawn_moves<Us, Type>(pos, moveList, target);
         for (PieceSet ps = pos.piece_types() & ~(piece_set(PAWN) | KING); ps;)
-            moveList = generate_moves<Us, Type>(pos, moveList, pop_lsb(ps), target);
+            moveList = generate_moves<Us, Type>(pos, moveList, pop_lsb(ps), target, captureTarget);
         // generate drops
         if (pos.piece_drops() && Type != CAPTURES && (pos.can_drop(Us, ALL_PIECES) || pos.two_boards()))
             for (PieceSet ps = pos.piece_types(); ps;)
@@ -455,8 +472,13 @@ namespace {
     // King moves
     if (pos.count<KING>(Us) && (!Checks || pos.blockers_for_king(~Us) & ksq))
     {
-        Bitboard b = (  (pos.attacks_from(Us, KING, ksq) & pos.pieces())
-                      | (pos.moves_from(Us, KING, ksq) & ~pos.pieces())) & (Type == EVASIONS ? ~pos.pieces(Us) : target);
+        Bitboard kingAttacks = pos.attacks_from(Us, KING, ksq) & pos.pieces();
+        Bitboard kingMoves   = pos.moves_from  (Us, KING, ksq) & ~pos.pieces();
+        Bitboard kingCaptureMask = Type == EVASIONS ? ~pos.pieces(Us) : captureTarget;
+        if (Type == EVASIONS && pos.self_capture())
+            kingCaptureMask |= pos.pieces(Us);
+        Bitboard kingQuietMask = Type == EVASIONS ? ~pos.pieces(Us) : target;
+        Bitboard b = (kingAttacks & kingCaptureMask) | (kingMoves & kingQuietMask);
         while (b)
             moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, ksq, pop_lsb(b));
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -455,6 +455,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("checking", v->checking);
     parse_attribute("dropChecks", v->dropChecks);
     parse_attribute("mustCapture", v->mustCapture);
+    parse_attribute("selfCapture", v->selfCapture);
     parse_attribute("mustDrop", v->mustDrop);
     parse_attribute("mustDropType", v->mustDropType, v->pieceToChar);
     parse_attribute("pieceDrops", v->pieceDrops);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1370,8 +1370,8 @@ bool Position::pseudo_legal(const Move m) const {
   if (pc == NO_PIECE || color_of(pc) != us)
       return false;
 
-  // The destination square cannot be occupied by a friendly piece
-  if (pieces(us) & to)
+  // The destination square cannot be occupied by a friendly piece unless self capture is allowed
+  if ((pieces(us) & to) && !(self_capture() && capture(m)))
       return false;
 
   // Handle the special case of a pawn move
@@ -1382,7 +1382,8 @@ bool Position::pseudo_legal(const Move m) const {
       if (mandatory_pawn_promotion() && (promotion_zone(us) & to) && !sittuyin_promotion())
           return false;
 
-      if (   !(pawn_attacks_bb(us, from) & pieces(~us) & to)     // Not a capture
+      if (   !(pawn_attacks_bb(us, from)
+              & (self_capture() ? pieces() : pieces(~us)) & to)     // Not a capture
           && !((from + pawn_push(us) == to) && !(pieces() & to)) // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)               // Not a double push
                && (double_step_region(us) & from)
@@ -1592,7 +1593,11 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   st->pass = is_pass(m);
 
   assert(color_of(pc) == us);
-  assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
+  assert(captured == NO_PIECE
+         || (type_of(m) == CASTLING
+             ? color_of(captured) == us
+             : (color_of(captured) == them
+                || (self_capture() && color_of(captured) == us))));
   assert(type_of(captured) != KING);
 
   if (check_counting() && givesCheck)
@@ -1629,7 +1634,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       if (type_of(captured) == PAWN)
           st->pawnKey ^= Zobrist::psq[captured][capsq];
       else
-          st->nonPawnMaterial[them] -= PieceValue[MG][captured];
+          st->nonPawnMaterial[color_of(captured)] -= PieceValue[MG][captured];
 
       if (Eval::useNNUE)
       {
@@ -2497,7 +2502,11 @@ bool Position::see_ge(Move m, Value threshold) const {
   if (must_capture() || !checking_permitted() || is_gating(m) || count<CLOBBER_PIECE>() == count<ALL_PIECES>())
       return VALUE_ZERO >= threshold;
 
-  int swap = PieceValue[MG][piece_on(to)] - threshold;
+  Piece victim = piece_on(to);
+  int victimValue = PieceValue[MG][victim];
+  if (victim != NO_PIECE && color_of(victim) == color_of(moved_piece(m)) && self_capture())
+      victimValue = -victimValue;
+  int swap = victimValue - threshold;
   if (swap < 0)
       return false;
 

--- a/src/position.h
+++ b/src/position.h
@@ -167,6 +167,7 @@ public:
   bool fast_attacks2() const;
   bool checking_permitted() const;
   bool drop_checks() const;
+  bool self_capture() const;
   bool must_capture() const;
   bool has_capture() const;
   bool must_drop() const;
@@ -641,6 +642,11 @@ inline bool Position::fast_attacks2() const {
 inline bool Position::drop_checks() const {
   assert(var != nullptr);
   return var->dropChecks;
+}
+
+inline bool Position::self_capture() const {
+  assert(var != nullptr);
+  return var->selfCapture;
 }
 
 inline bool Position::must_capture() const {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -50,6 +50,13 @@ namespace {
         v->nnueAlias = "nn-";
         return v;
     }
+    // Capture Anything Chess
+    // https://www.chess.com/terms/capture-anything-chess
+    Variant* capture_anything_variant() {
+        Variant* v = chess_variant()->init();
+        v->selfCapture = true;
+        return v;
+    }
     // Chess960 aka Fischer random chess
     // https://en.wikipedia.org/wiki/Fischer_random_chess
     Variant* chess960_variant() {
@@ -1832,6 +1839,7 @@ void VariantMap::init() {
     add("fischerandom", chess960_variant());
     add("nocastle", nocastle_variant());
     add("armageddon", armageddon_variant());
+    add("capture-anything", capture_anything_variant());
     add("torpedo", torpedo_variant());
     add("berolina", berolina_variant());
     add("pawnsideways", pawnsideways_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -66,6 +66,8 @@ struct Variant {
   bool blastOnCapture = false;
   PieceSet blastImmuneTypes = NO_PIECE_SET;
   PieceSet mutuallyImmuneTypes = NO_PIECE_SET;
+  // Allow capturing pieces of the same color (friendly capture)
+  bool selfCapture = false;
   // Iron pieces: attempts to capture these piece types are illegal
   PieceSet ironPieceTypes = NO_PIECE_SET;
   PieceSet petrifyOnCaptureTypes = NO_PIECE_SET;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -185,6 +185,7 @@
 # blastOnCapture: captures explode all adjacent non-pawn pieces (e.g., atomic chess) [bool] (default: false)
 # blastImmuneTypes: pieces completely immune to explosions (even at ground zero) [PieceSet] (default: none)
 # mutuallyImmuneTypes: pieces that can't capture another piece of same types (e.g., kings (commoners) in atomar) [PieceSet] (default: none)
+# selfCapture: allow capturing one's own pieces [bool] (default: false)
 # ironPieceTypes: pieces that are uncapturable (attempting to capture them is illegal) [PieceSet] (default: none)
 # petrifyOnCaptureTypes: defined pieces are turned into wall squares when capturing [PieceSet] (default: -)
 # petrifyBlastPieces: if petrify and blast combined, should pieces destroyed in the blast be petrified? [bool] (default: false)
@@ -2050,3 +2051,9 @@ mandatoryPiecePromotion = true
 # Iron pieces demo: pawns are uncapturable; everything else behaves normally.
 [iron-pawns:chess]
 ironPieceTypes = p
+
+# Chess, but you may capture your own pieces and pawns
+# https://www.chess.com/terms/capture-anything-chess
+[capture-anything:chess]
+name = Capture Anything
+selfCapture = true

--- a/test.py
+++ b/test.py
@@ -698,6 +698,27 @@ class TestPyffish(unittest.TestCase):
         result = sf.get_fen("cambodian", fen, moves, False, False, True)
         self.assertEqual(result, "Rnsmksnr/8/1ppppppp/8/8/1PPPPPPP/8/1NSKMSNR b DEd - 0 1")
 
+    def test_capture_anything_knight_self_capture(self):
+        chess_start = sf.start_fen("chess")
+        chess_moves = sf.legal_moves("chess", chess_start, [])
+        self.assertNotIn("g1e2", chess_moves)
+
+        capture_anything_start = sf.start_fen("capture-anything")
+        capture_moves = sf.legal_moves("capture-anything", capture_anything_start, [])
+        self.assertIn("g1e2", capture_moves)
+
+        san = sf.get_san("capture-anything", capture_anything_start, "g1e2")
+        self.assertIn("x", san)
+
+    def test_capture_anything_pawn_self_capture_resets_clock(self):
+        fen = "8/8/8/5N2/4P3/8/8/8 w - - 17 1"
+        moves = sf.legal_moves("capture-anything", fen, [])
+        self.assertIn("e4f5", moves)
+        self.assertTrue(sf.is_capture("capture-anything", fen, [], "e4f5"))
+
+        new_fen = sf.get_fen("capture-anything", fen, ["e4f5"])
+        self.assertEqual(int(new_fen.split()[4]), 0)
+
     def test_get_san(self):
         fen = "4k3/8/3R4/8/1R3R2/8/3R4/4K3 w - - 0 1"
         result = sf.get_san("chess", fen, "b4d4")


### PR DESCRIPTION
## Summary
- add a selfCapture rule flag with parser support and expose a capture-anything preset
- teach move generation, legality, bookkeeping and SEE to handle friendly captures
- cover the rule with regression tests for knight and pawn self-captures

## Testing
- `make -j2 ARCH=x86-64 build`
- `python3 test.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc6d93496c8322954827ff975b91ee