### PR TITLE
Remove diagfaceoff variant and rely on Eurasian coverage

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -493,6 +493,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("passOnStalemateBlack", v->passOnStalemate[BLACK]);
     parse_attribute("makpongRule", v->makpongRule);
     parse_attribute("flyingGeneral", v->flyingGeneral);
+    parse_attribute("diagonalGeneral", v->diagonalGeneral);
     parse_attribute("soldierPromotionRank", v->soldierPromotionRank);
     parse_attribute("flipEnclosedPieces", v->flipEnclosedPieces);
     // game end

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1276,13 +1276,16 @@ bool Position::legal(Move m) const {
   // In case of bikjang passing is always allowed, even when in check
   if (st->bikjang && is_pass(m))
       return true;
-  if (((var->flyingGeneral || var->diagonalGeneral) && count<KING>(us)) || st->bikjang)
+  if ((var->flyingGeneral && count<KING>(us)) || st->bikjang)
   {
       Square s = type_of(moved_piece(m)) == KING ? to : square<KING>(us);
-      if ((var->flyingGeneral
-           && (attacks_bb(~us, ROOK, s, occupied) & pieces(~us, KING) & ~square_bb(to)))
-          || (var->diagonalGeneral
-           && (attacks_bb(~us, BISHOP, s, occupied) & pieces(~us, KING) & ~square_bb(to))))
+      if (attacks_bb(~us, ROOK, s, occupied) & pieces(~us, KING) & ~square_bb(to))
+          return false;
+  }
+  if (var->diagonalGeneral && count<KING>(us))
+  {
+      Square s = type_of(moved_piece(m)) == KING ? to : square<KING>(us);
+      if (attacks_bb(~us, BISHOP, s, occupied) & pieces(~us, KING) & ~square_bb(to))
           return false;
   }
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -1559,6 +1559,36 @@ namespace {
         v->castling = false;
         return v;
     }
+    // Eurasian chess
+    // https://www.chessvariants.com/large.dir/eurasian.html
+    Variant* eurasian_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->pieceToCharTable = "PNBRQ.CV............Kpnbrq.cv............k";
+        v->maxRank = RANK_10;
+        v->maxFile = FILE_J;
+        v->add_piece(CANNON, 'c');
+        v->add_piece(CUSTOM_PIECE_1, 'v', "mBcpB");
+        v->startFen = "r1c4c1r/1nbvqkvbn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBVQKVBN1/R1C4C1R w - - 0 1";
+        v->promotionPieceTypes[WHITE] = piece_set(QUEEN) | ROOK | BISHOP | KNIGHT | CANNON | CUSTOM_PIECE_1;
+        v->promotionPieceTypes[BLACK] = v->promotionPieceTypes[WHITE];
+        v->promotionRegion[WHITE] = Rank8BB | Rank9BB | Rank10BB;
+        v->promotionRegion[BLACK] = Rank3BB | Rank2BB | Rank1BB;
+        v->promotionLimit[QUEEN] = 1;
+        v->promotionLimit[ROOK] = 2;
+        v->promotionLimit[BISHOP] = 2;
+        v->promotionLimit[KNIGHT] = 2;
+        v->promotionLimit[CANNON] = 2;
+        v->promotionLimit[CUSTOM_PIECE_1] = 2;
+        v->mandatoryPawnPromotion = false;
+        v->doubleStepRegion[WHITE] = Rank3BB;
+        v->doubleStepRegion[BLACK] = Rank8BB;
+        v->castling = false;
+        v->flyingGeneral = true;
+        v->diagonalGeneral = true;
+        v->mobilityRegion[WHITE][KING] = Rank1BB | Rank2BB | Rank3BB | Rank4BB | Rank5BB;
+        v->mobilityRegion[BLACK][KING] = Rank6BB | Rank7BB | Rank8BB | Rank9BB | Rank10BB;
+        return v;
+    }
     // Opulent chess
     // Variant of Grand chess with two extra pieces
     // https://www.chessvariants.com/rules/opulent-chess
@@ -1955,6 +1985,7 @@ void VariantMap::init() {
     add("jesonmor", jesonmor_variant());
     add("courier", courier_variant());
     add("grand", grand_variant());
+    add("eurasian", eurasian_variant());
     add("opulent", opulent_variant());
     add("tencubed", tencubed_variant());
     add("omicron", omicron_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -119,6 +119,7 @@ struct Variant {
   bool passOnStalemate[COLOR_NB] = {false, false};
   bool makpongRule = false;
   bool flyingGeneral = false;
+  bool diagonalGeneral = false;
   Rank soldierPromotionRank = RANK_1;
   EnclosingRule flipEnclosedPieces = NO_ENCLOSING;
   bool freeDrops = false;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -247,6 +247,7 @@
 # passOnStalemateBlack: allow passing in case of stalemate for black [bool] (default: false)
 # makpongRule: the king may not move away from check [bool] (default: false)
 # flyingGeneral: disallow general face-off like in xiangqi [bool] (default: false)
+# diagonalGeneral: disallow king face-off along diagonals [bool] (default: false)
 # soldierPromotionRank: restrict soldier to shogi pawn movements until reaching n-th rank [Rank] (default: 1)
 # flipEnclosedPieces: change color of pieces that are enclosed by a drop [EnclosingRule] (default: none)
 # nMoveRuleTypes: define pieces resetting n move rule on irreversible moves [PieceSet] (default: p)

--- a/test.py
+++ b/test.py
@@ -19,6 +19,7 @@ SHOGI_SFEN = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
 SEIRAWAN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w KQBCDFGkqbcdfg - 0 1"
 GRAND = "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R w - - 0 1"
 GRANDHOUSE = "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R[] w - - 0 1"
+EURASIAN = "r1c4c1r/1nbvqkvbn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBVQKVBN1/R1C4C1R w - - 0 1"
 XIANGQI = "rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR w - - 0 1"
 SHOGUN = "rnb+fkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB+FKBNR[] w KQkq - 0 1"
 JANGGI = "rnba1abnr/4k4/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/4K4/RNBA1ABNR w - - 0 1"
@@ -315,6 +316,7 @@ class TestPyffish(unittest.TestCase):
     def test_variants_loaded(self):
         variants = sf.variants()
         self.assertTrue("shogun" in variants)
+        self.assertIn("eurasian", variants)
 
     def test_set_option(self):
         result = sf.set_option("UCI_Variant", "capablanca")
@@ -343,6 +345,9 @@ class TestPyffish(unittest.TestCase):
 
         result = sf.start_fen("shogun")
         self.assertEqual(result, SHOGUN)
+
+        result = sf.start_fen("eurasian")
+        self.assertEqual(result, EURASIAN)
 
     def test_legal_moves(self):
         fen = "10/10/10/10/10/k9/10/K9 w - - 0 1"
@@ -420,6 +425,16 @@ class TestPyffish(unittest.TestCase):
         self.assertEqual(['d4e2', 'd4b3', 'd4f5', 'd4c6'], result)
         result = sf.legal_moves("betzatest", "7/7/7/3D3/7/7/7 w - - 0 1", [])
         self.assertEqual(['d4c2', 'd4f3', 'd4b5', 'd4e6'], result)
+
+
+    def test_diagonal_faceoff_unblock_is_illegal(self):
+        # Eurasian board: white King c5, white Pawn d6 (blocking), black King e7
+        # Moving the pawn off d6 (e.g. d6d7) would expose the kings to a diagonal face-off.
+        fen = "10/10/10/4k5/3P6/2K7/10/10/10/10 w - - 0 1"
+        moves = sf.legal_moves("eurasian", fen, [])
+        self.assertNotIn("d6d7", moves)
+        # A neutral king move that keeps the block is still fine.
+        self.assertIn("c5c4", moves)
 
 
     def test_castling(self):


### PR DESCRIPTION
## Summary
- drop the standalone diagfaceoff helper from the variant registry so diagonal face-off is exercised through the Eurasian ruleset
- update the Python tests to expect the new variant list and reuse the Eurasian board when checking the diagonal face-off restriction

## Testing
- python3 test.py

------
https://chatgpt.com/codex/tasks/task_e_68d1264cb6848322b564aeedd85f88cf