### PR TITLE
Add check-only move modality support

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -109,10 +109,13 @@ extern Bitboard PseudoAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PseudoMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard LeaperAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard LeaperMoves[2][COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
+extern Bitboard PseudoCheckAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
+extern Bitboard LeaperCheckAttacks[COLOR_NB][PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard SquareBB[SQUARE_NB];
 extern Bitboard BoardSizeBB[FILE_NB][RANK_NB];
 extern RiderType AttackRiderTypes[PIECE_TYPE_NB];
 extern RiderType MoveRiderTypes[2][PIECE_TYPE_NB];
+extern RiderType CheckRiderTypes[PIECE_TYPE_NB];
 
 #ifdef LARGEBOARDS
 int popcount(Bitboard b); // required for 128 bit pext
@@ -476,6 +479,14 @@ inline Bitboard attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
   while (r)
       b |= rider_attacks_bb(pop_rider(&r), s, occupied);
   return b & PseudoAttacks[c][pt][s];
+}
+
+inline Bitboard check_attacks_bb(Color c, PieceType pt, Square s, Bitboard occupied) {
+  Bitboard b = LeaperCheckAttacks[c][pt][s];
+  RiderType r = CheckRiderTypes[pt];
+  while (r)
+      b |= rider_attacks_bb(pop_rider(&r), s, occupied);
+  return b & PseudoCheckAttacks[c][pt][s];
 }
 
 

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -67,8 +67,10 @@ namespace {
       {
           char c = betza[i];
           // Modality
-          if (c == 'm' || c == 'c')
-              moveModalities.push_back(c == 'c' ? MODALITY_CAPTURE : MODALITY_QUIET);
+          if (c == 'm' || c == 'c' || c == 'k')
+              moveModalities.push_back(c == 'c' ? MODALITY_CAPTURE
+                                       : c == 'k' ? MODALITY_CHECK
+                                                  : MODALITY_QUIET);
           // Hopper
           else if (c == 'p' || c == 'g')
           {

--- a/src/piece.h
+++ b/src/piece.h
@@ -27,7 +27,7 @@
 
 namespace Stockfish {
 
-enum MoveModality {MODALITY_QUIET, MODALITY_CAPTURE, MOVE_MODALITY_NB};
+enum MoveModality {MODALITY_QUIET, MODALITY_CAPTURE, MODALITY_CHECK, MOVE_MODALITY_NB};
 
 /// PieceInfo struct stores information about the piece movements.
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -587,7 +587,7 @@ void Position::set_check_info(StateInfo* si) const {
                               | check_attacks_bb(~sideToMove, movePt, ksq, pieces()))
                            : Bitboard(0);
       // Collect special piece types that require slower check and evasion detection
-      if (AttackRiderTypes[movePt] & NON_SLIDING_RIDERS)
+      if ((AttackRiderTypes[movePt] | CheckRiderTypes[movePt]) & NON_SLIDING_RIDERS)
           si->nonSlidingRiders |= pieces(pt);
   }
   si->shak = si->checkersBB & (byTypeBB[KNIGHT] | byTypeBB[ROOK] | byTypeBB[BERS]);
@@ -976,7 +976,18 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
           else
               b |= attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
 
-          b |= check_attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
+          if (CheckRiderTypes[move_pt] & ASYMMETRICAL_RIDERS)
+          {
+              Bitboard asymmetricals = PseudoCheckAttacks[~c][move_pt][s] & pieces(c, pt);
+              while (asymmetricals)
+              {
+                  Square s2 = pop_lsb(asymmetricals);
+                  if (check_attacks_bb(c, move_pt, s2, occupied) & s)
+                      b |= s2;
+              }
+          }
+          else
+              b |= check_attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
       }
   }
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -582,7 +582,10 @@ void Position::set_check_info(StateInfo* si) const {
   {
       PieceType pt = pop_lsb(ps);
       PieceType movePt = pt == KING ? king_type() : pt;
-      si->checkSquares[pt] = ksq != SQ_NONE ? attacks_bb(~sideToMove, movePt, ksq, pieces()) : Bitboard(0);
+      si->checkSquares[pt] = ksq != SQ_NONE
+                           ? (attacks_bb(~sideToMove, movePt, ksq, pieces())
+                              | check_attacks_bb(~sideToMove, movePt, ksq, pieces()))
+                           : Bitboard(0);
       // Collect special piece types that require slower check and evasion detection
       if (AttackRiderTypes[movePt] & NON_SLIDING_RIDERS)
           si->nonSlidingRiders |= pieces(pt);
@@ -972,6 +975,8 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
               b |= attacks_bb(~c, move_pt, s, occupied) & attacks_bb(~c, move_pt, s, occupied & ~janggiCannons) & pieces(c, JANGGI_CANNON);
           else
               b |= attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
+
+          b |= check_attacks_bb(~c, move_pt, s, occupied) & pieces(c, pt);
       }
   }
 


### PR DESCRIPTION
## Summary
- extend Betza move parsing and modality enum with the new check-only `k` qualifier
- build precomputed data for check-only attacks and include them in attack detection and check-square bookkeeping

## Testing
- `cd src && make -j2 ARCH=x86-64 build`


------
https://chatgpt.com/codex/tasks/task_e_68d12f3fd62c83229eb36b0733dee539