### PR TITLE
Improve bughouse partner coordination

### DIFF
--- a/src/partner.h
+++ b/src/partner.h
@@ -19,8 +19,10 @@
 #ifndef PARTNER_H_INCLUDED
 #define PARTNER_H_INCLUDED
 
+#include <array>
 #include <atomic>
 #include <sstream>
+#include <vector>
 
 #include "misc.h"
 #include "position.h"
@@ -42,11 +44,20 @@ struct PartnerHandler {
     void ptell(const std::string& message);
     void parse_partner(std::istringstream& is);
     void parse_ptell(std::istringstream& is, const Position& pos);
+    void update_piece_flow(const Position& rootPos, const std::vector<Move>& pv);
 
     std::atomic<bool> isFairy;
     std::atomic<bool> fast, sitRequested, partnerDead, weDead, weWin, weVirtualWin, weVirtualLoss;
     std::atomic<TimePoint> time, opptime;
     Move moveRequested;
+    std::atomic<uint64_t> partnerNeedsMask;
+    std::atomic<uint64_t> partnerBansMask;
+    std::atomic<uint64_t> ourNeedsMask;
+    std::string lastFlowSummary;
+    std::string lastNeedSummary;
+    uint64_t lastDeliveredMask;
+    uint64_t lastBlockedMask;
+    TimePoint lastSitAnnounce;
 };
 
 extern PartnerHandler Partner;

--- a/src/partner.h
+++ b/src/partner.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <atomic>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "misc.h"
@@ -55,6 +56,7 @@ struct PartnerHandler {
     std::atomic<uint64_t> ourNeedsMask;
     std::string lastFlowSummary;
     std::string lastNeedSummary;
+    std::string lastFeedSummary;
     uint64_t lastDeliveredMask;
     uint64_t lastBlockedMask;
     TimePoint lastSitAnnounce;


### PR DESCRIPTION
## Summary
- add partner piece-flow analysis to share expected captures, drops, and outstanding requests with bughouse partners
- support parsing new partner commands for requesting or banning pieces and maintain related handler state
- report sit-status updates during bughouse coordination to improve time management feedback

## Testing
- make -j2 ARCH=x86-64 build

------
https://chatgpt.com/codex/tasks/task_e_68d12fd4d9c083229503d7da01be9365