### PR TITLE
Add reverse material counting support

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -547,10 +547,11 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("collinearN", v->collinearN);
     parse_attribute("connectValue", v->connectValue);
     parse_attribute("materialCounting", v->materialCounting);
+    parse_attribute("reverseMaterialCounting", v->reverseMaterialCounting);
     parse_attribute("adjudicateFullBoard", v->adjudicateFullBoard);
     parse_attribute("countingRule", v->countingRule);
     parse_attribute("castlingWins", v->castlingWins);
-    
+
     // Report invalid options
     if (DoCheck)
     {

--- a/src/position.h
+++ b/src/position.h
@@ -928,7 +928,12 @@ inline Value Position::stalemate_value(int ply) const {
   if (var->stalematePieceCount)
   {
       int c = count<ALL_PIECES>(sideToMove) - count<ALL_PIECES>(~sideToMove);
-      return c == 0 ? VALUE_DRAW : convert_mate_value(c < 0 ? var->stalemateValue : -var->stalemateValue, ply);
+      if (c == 0)
+          return VALUE_DRAW;
+      Value v = c < 0 ? var->stalemateValue : -var->stalemateValue;
+      if (var->reverseMaterialCounting)
+          v = -v;
+      return convert_mate_value(v, ply);
   }
   // Check for checkmate of pseudo-royal pieces
   if (var->extinctionPseudoRoyal)
@@ -1628,7 +1633,8 @@ inline Value Position::material_counting_result() const {
       assert(false);
       result = VALUE_DRAW;
   }
-  return sideToMove == WHITE ? result : -result;
+  Value finalResult = sideToMove == WHITE ? result : -result;
+  return var->reverseMaterialCounting ? -finalResult : finalResult;
 }
 
 inline void Position::add_to_hand(Piece pc) {

--- a/src/variant.h
+++ b/src/variant.h
@@ -163,6 +163,7 @@ struct Variant {
   int collinearN = 0;
   Value connectValue = VALUE_MATE;
   MaterialCounting materialCounting = NO_MATERIAL_COUNTING;
+  bool reverseMaterialCounting = false; // reverse the winner determined by materialCounting
   bool adjudicateFullBoard = false;
   CountingRule countingRule = NO_COUNTING;
   CastlingRights castlingWins = NO_CASTLING;

--- a/src/variants.ini
+++ b/src/variants.ini
@@ -296,6 +296,7 @@
 # collinearN: arrange N pieces collinearly (other squares can be between pieces) [int] (default: 0)
 # connectValue: result in case of connect [Value] (default: win)
 # materialCounting: enable material counting rules [MaterialCounting] (default: none)
+# reverseMaterialCounting: invert the result of material counting rules [bool] (default: false)
 # adjudicateFullBoard: apply material counting immediately when board is full [bool] (default: false)
 # countingRule: enable counting rules [CountingRule] (default: none)
 # castlingWins: Specified castling moves are win conditions. Losing these rights is losing. [CastlingRights] (default: -)


### PR DESCRIPTION
## Summary
- add a reverseMaterialCounting option to variants and expose it through the parser
- honor the reversed sign in stalemate and material counting evaluations
- document the new configuration toggle in variants.ini

## Testing
- make -j2 ARCH=x86-64 build

------
https://chatgpt.com/codex/tasks/task_e_68d14964a2508322a92723dc58718340