### PR TITLE
Improve insufficient material handling for configured pieces

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -389,6 +389,7 @@ inline CustomPieceMaterial classify_custom_piece(const Position& pos, PieceType 
 
     bool hasAttacks = false;
     bool hasColorChange = false;
+    bool hasNonAdjacentAttacks = false;
     int maxAdjacency = 0;
 
     for (Bitboard squares = region; squares;)
@@ -399,10 +400,14 @@ inline CustomPieceMaterial classify_custom_piece(const Position& pos, PieceType 
             continue;
 
         hasAttacks = true;
-        Bitboard adjacency = attacks & (PseudoAttacks[WHITE][KING][s] & board);
+        Bitboard kingAdjacency = PseudoAttacks[WHITE][KING][s] & board;
+        Bitboard adjacency = attacks & kingAdjacency;
         int adjacencyCount = popcount(adjacency);
         if (adjacencyCount > maxAdjacency)
             maxAdjacency = adjacencyCount;
+
+        if (attacks & ~kingAdjacency)
+            hasNonAdjacentAttacks = true;
 
         Bitboard tmp = attacks;
         while (tmp)
@@ -442,7 +447,7 @@ inline CustomPieceMaterial classify_custom_piece(const Position& pos, PieceType 
     }
 
     bool sliderBased = hasLongSlider && hasColorChange;
-    bool adjacencyBased = hasColorChange && maxAdjacency >= 5;
+    bool adjacencyBased = hasColorChange && maxAdjacency >= 4 && hasNonAdjacentAttacks;
 
     result.major = sliderBased || adjacencyBased;
     return result;

--- a/test.py
+++ b/test.py
@@ -136,6 +136,14 @@ pawnTypes = ps
 # Capture-anything: allow self-capture while keeping standard chess rules otherwise
 [capture-anything:chess]
 selfCapture = true
+
+[customqueen:chess]
+customPiece1 = a:Q
+startFen = 4k3/8/8/8/4A3/8/8/4K3 w - - 0 1
+
+[custombishop:chess]
+customPiece1 = a:B
+startFen = 4k3/8/8/8/4A3/8/8/4K3 w - - 0 1
 """
 
 sf.load_variant_config(ini_text)
@@ -255,6 +263,12 @@ variant_positions = {
     "multipawn": {
         "k7/p7/8/8/8/8/8/K7 w - - 0 1": (True, False),  # K vs KP
         "k7/s7/8/8/8/8/8/K7 w - - 0 1": (True, False),  # K vs KS
+    },
+    "customqueen": {
+        "4k3/8/8/8/4A3/8/8/4K3 w - - 0 1": (False, True),  # KA vs K
+    },
+    "custombishop": {
+        "4k3/8/8/8/4A3/8/8/4K3 w - - 0 1": (True, True),  # KB vs K
     },
 }
 


### PR DESCRIPTION
## Summary
- classify configured pieces by analysing their move sets to determine color-bound and major piece behaviour
- apply the new classification inside has_insufficient_material so configured pieces no longer assume mating potential by default
- add custom queen and bishop variants plus regression tests to cover configured-piece insufficient material cases

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'pyffish')*
- `python3 setup.py build_ext --inplace` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_68d149c295d4832295d946a030bb2be3