### PR TITLE
Hide gating suffix and finish Battle of the Kings extinction

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -64,7 +64,23 @@ namespace {
         return moveList;
     }
 
-    *moveList++ = make<T>(from, to, pt);
+    PieceType forcedGate = NO_PIECE_TYPE;
+    Square forcedGateSquare = SQ_NONE;
+    if (from != to)
+    {
+        Piece pcFrom = pos.piece_on(from);
+        if (pcFrom != NO_PIECE)
+        {
+            forcedGate = pos.forced_gating_type(us, type_of(pcFrom));
+            if (forcedGate != NO_PIECE_TYPE)
+                forcedGateSquare = from;
+        }
+    }
+
+    if (forcedGate != NO_PIECE_TYPE)
+        *moveList++ = make_gating<T>(from, to, forcedGate, forcedGateSquare);
+    else
+        *moveList++ = make<T>(from, to, pt);
 
     // Gating moves
     if (pos.seirawan_gating() && (pos.gates(us) & from))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1263,6 +1263,15 @@ bool Position::legal(Move m) const {
 
   Bitboard occupied = (type_of(m) != DROP ? pieces() ^ from : pieces()) | to;
 
+  if (is_gating(m) && gating_type(m) == KING)
+  {
+      Bitboard occ = occupied | gating_square(m);
+      if (type_of(m) == EN_PASSANT)
+          occ ^= capture_square(to);
+      if (attackers_to(gating_square(m), occ, ~us))
+          return false;
+  }
+
   // Flying general rule and bikjang
   // In case of bikjang passing is always allowed, even when in check
   if (st->bikjang && is_pass(m))
@@ -1976,7 +1985,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       }
 
       put_piece(gating_piece, gate);
-      remove_from_hand(gating_piece);
+      if (gating_from_hand())
+          remove_from_hand(gating_piece);
 
       st->gatesBB[us] ^= gate;
       k ^= Zobrist::psq[gating_piece][gate];
@@ -2204,7 +2214,8 @@ void Position::undo_move(Move m) {
       Piece gating_piece = make_piece(us, gating_type(m));
       remove_piece(gating_square(m));
       board[gating_square(m)] = NO_PIECE;
-      add_to_hand(gating_piece);
+      if (gating_from_hand())
+          add_to_hand(gating_piece);
       st->gatesBB[us] |= gating_square(m);
   }
 
@@ -2785,6 +2796,8 @@ bool Position::is_immediate_game_end(Value& result, int ply) const {
           for (PieceSet ps = extinction_piece_types(); ps;)
           {
               PieceType pt = pop_lsb(ps);
+              if ((extinction_must_appear() & piece_set(pt)) && !(st->extinctionSeen[c] & piece_set(pt)))
+                  continue;
               if (   count_with_hand( c, pt) <= var->extinctionPieceCount
                   && count_with_hand(~c, pt) >= var->extinctionOpponentPieceCount + (extinction_claim() && c == sideToMove))
               {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1977,10 +1977,18 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       {
           // Add gating piece
           dp.piece[dp.dirty_num] = gating_piece;
-          dp.handPiece[dp.dirty_num] = gating_piece;
-          dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
           dp.from[dp.dirty_num] = SQ_NONE;
           dp.to[dp.dirty_num] = gate;
+          if (gating_from_hand())
+          {
+              dp.handPiece[dp.dirty_num] = gating_piece;
+              dp.handCount[dp.dirty_num] = pieceCountInHand[us][gating_type(m)];
+          }
+          else
+          {
+              dp.handPiece[dp.dirty_num] = NO_PIECE;
+              dp.handCount[dp.dirty_num] = 0;
+          }
           dp.dirty_num++;
       }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -546,8 +546,13 @@ string UCI::move(const Position& pos, Move m) {
       move += '-';
   else if (is_gating(m))
   {
-      move += pos.piece_to_char()[make_piece(BLACK, gating_type(m))];
-      if (gating_square(m) != from)
+      if (pos.gating_from_hand())
+      {
+          move += pos.piece_to_char()[make_piece(BLACK, gating_type(m))];
+          if (gating_square(m) != from)
+              move += UCI::square(pos, gating_square(m));
+      }
+      else if (gating_square(m) != from)
           move += UCI::square(pos, gating_square(m));
   }
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -756,6 +756,31 @@ namespace {
         v->promotionPieceTypes[BLACK] = piece_set(ARCHBISHOP) | CHANCELLOR | QUEEN | ROOK | BISHOP | KNIGHT;
         return v;
     }
+    // Battle of the Kings
+    // https://www.chessvariants.com/rules/battle-of-kings-
+    Variant* battle_kings_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->startFen = "8/pppppppp/8/8/8/8/PPPPPPPP/8 w - - 0 1";
+        v->castling = false;
+        v->gating = true;
+        v->gatingFromHand = false;
+        for (Color c : {WHITE, BLACK})
+        {
+            v->gatingPieceAfter[c][PAWN] = KNIGHT;
+            v->gatingPieceAfter[c][KNIGHT] = BISHOP;
+            v->gatingPieceAfter[c][BISHOP] = ROOK;
+            v->gatingPieceAfter[c][ROOK] = QUEEN;
+            v->gatingPieceAfter[c][QUEEN] = KING;
+        }
+        v->stalemateValue = -VALUE_MATE;
+        v->nMoveRule = 0;
+        v->nFoldRule = 2;
+        v->nFoldValue = VALUE_MATE;
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = piece_set(KING);
+        v->extinctionMustAppear = piece_set(KING);
+        return v;
+    }
     // S-House
     // A hybrid variant of S-Chess and Crazyhouse.
     // Pieces in the pocket can either be gated or dropped.
@@ -1908,6 +1933,7 @@ void VariantMap::init() {
     add("placement", placement_variant());
     add("sittuyin", sittuyin_variant());
     add("seirawan", seirawan_variant());
+    add("battlekings", battle_kings_variant());
     add("shouse", shouse_variant());
     add("dragon", dragon_variant());
     add("paradigm", paradigm_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -27,6 +27,7 @@
 #include <functional>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 #include "types.h"
 #include "bitboard.h"
@@ -109,6 +110,8 @@ struct Variant {
   int dropNoDoubledCount = 1;
   bool immobilityIllegal = false;
   bool gating = false;
+  bool gatingFromHand = true;
+  PieceType gatingPieceAfter[COLOR_NB][PIECE_TYPE_NB] = {};
   WallingRule wallingRule = NO_WALLING;
   Bitboard wallingRegion[COLOR_NB] = {AllSquares, AllSquares};
   bool wallOrMove = false;
@@ -143,6 +146,7 @@ struct Variant {
   bool extinctionPseudoRoyal = false;
   bool dupleCheck = false;
   PieceSet extinctionPieceTypes = NO_PIECE_SET;
+  PieceSet extinctionMustAppear = NO_PIECE_SET;
   int extinctionPieceCount = 0;
   int extinctionOpponentPieceCount = 0;
   PieceType flagPiece[COLOR_NB] = {ALL_PIECES, ALL_PIECES};
@@ -226,6 +230,10 @@ struct Variant {
   Variant* init() {
       nnueAlias = "";
       endgameEval = EG_EVAL_CHESS;
+      gatingFromHand = true;
+      extinctionMustAppear = NO_PIECE_SET;
+      for (Color c : {WHITE, BLACK})
+          std::fill(std::begin(gatingPieceAfter[c]), std::end(gatingPieceAfter[c]), NO_PIECE_TYPE);
       return this;
   }
 


### PR DESCRIPTION
## Summary
- hide forced gating suffixes from coordinate notation so promotion choices remain unambiguous
- add extinction tracking for Battle of the Kings and only trigger the rule once a king has appeared
- update the Battle of the Kings python tests for the revised move strings

## Testing
- make -j2 ARCH=x86-64 build
- python3 -m unittest test.TestPyffish

------
https://chatgpt.com/codex/tasks/task_e_68d14c54c3348322acceac0979446f6d