### PR TITLE
Refine freeze potion heuristics

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - work
   pull_request:
     branches:
       - master
+      - work
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, work ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, work ]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, work ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, work ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,10 +5,12 @@ on:
       - master
       - tools
       - github_ci
+      - work
   pull_request:
     branches:
       - master
       - tools
+      - work
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,9 +4,11 @@ on:
     push:
       branches:
         - master
+        - work
     pull_request:
       branches:
         - master
+        - work
 
 jobs:
   build_wheels:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -73,12 +73,14 @@ bool MovePicker::is_useless_potion(Move m) const {
       {
           Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
           Color us = pos.side_to_move();
-          Bitboard enemies = pos.pieces(~us);
+          Color them = ~us;
+
+          Bitboard enemies = pos.pieces(them) & ~pos.freeze_squares(them);
           int enemyCount = popcount(zone & enemies);
           if (!enemyCount)
               return true;
 
-          Bitboard friendlies = pos.pieces(us);
+          Bitboard friendlies = pos.pieces(us) & ~pos.freeze_squares(us);
           int friendlyCount = popcount(zone & friendlies);
           return friendlyCount > enemyCount;
       }

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -72,8 +72,15 @@ bool MovePicker::is_useless_potion(Move m) const {
       if (potion == Variant::POTION_FREEZE)
       {
           Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
-          Bitboard enemies = pos.pieces(~pos.side_to_move());
-          return !(zone & enemies);
+          Color us = pos.side_to_move();
+          Bitboard enemies = pos.pieces(~us);
+          int enemyCount = popcount(zone & enemies);
+          if (!enemyCount)
+              return true;
+
+          Bitboard friendlies = pos.pieces(us);
+          int friendlyCount = popcount(zone & friendlies);
+          return friendlyCount > enemyCount;
       }
 
       if (potion == Variant::POTION_JUMP)


### PR DESCRIPTION
## Summary
- refine the freeze potion gating filter to require enemy targets and account for friendly pieces in the zone
- skip freeze moves that would immobilize more of our own pieces than opponents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daac4096b4832292b258bfcfb2447a