### PR TITLE
Revert freeze potion heuristic adjustments

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - work
   pull_request:
     branches:
       - master
+      - work
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -4,10 +4,14 @@ on:
     branches:
       - master
       - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
   pull_request:
     branches:
       - master
       - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,17 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, work ]
+    branches:
+      - master
+      - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
   pull_request:
-    branches: [ master, work ]
+    branches:
+      - master
+      - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, work ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, work ]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,17 @@ name: Release
 
 on:
   push:
-    branches: [ master, work ]
+    branches:
+      - master
+      - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
   pull_request:
-    branches: [ master, work ]
+    branches:
+      - master
+      - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
 
 jobs:
   windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, work ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, work ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -6,11 +6,15 @@ on:
       - tools
       - github_ci
       - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
   pull_request:
     branches:
       - master
       - tools
       - work
+      - Experimental-spell-heuristics
+      - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,10 +5,12 @@ on:
       - master
       - tools
       - github_ci
+      - work
   pull_request:
     branches:
       - master
       - tools
+      - work
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,10 +5,14 @@ on:
       branches:
         - master
         - work
+        - Experimental-spell-heuristics
+        - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
     pull_request:
       branches:
         - master
         - work
+        - Experimental-spell-heuristics
+        - 'codex/implement-freeze-net-impact-scoring-heuristic-b2cbre'
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,9 +4,11 @@ on:
     push:
       branches:
         - master
+        - work
     pull_request:
       branches:
         - master
+        - work
 
 jobs:
   build_wheels:


### PR DESCRIPTION
## Summary
- restore the original freeze potion gating logic that only filters out zones without enemy targets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daac4096b4832292b258bfcfb2447a