### PR TITLE
Add net-impact scoring for freeze potions

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -31,6 +31,8 @@ int history_slot(Piece pc) {
 
 namespace {
 
+  constexpr int FreezeNetImpactWeight = 256;
+
   enum Stages {
     MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
     EVASION_TT, EVASION_INIT, EVASION,
@@ -71,18 +73,14 @@ bool MovePicker::is_useless_potion(Move m) const {
 
       if (potion == Variant::POTION_FREEZE)
       {
-          Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
-          Color us = pos.side_to_move();
-          Color them = ~us;
+          FreezeImpact impact;
+          if (!freeze_impact(m, impact))
+              return false;
 
-          Bitboard enemies = pos.pieces(them) & ~pos.freeze_squares(them);
-          int enemyCount = popcount(zone & enemies);
-          if (!enemyCount)
+          if (!impact.enemyCount)
               return true;
 
-          Bitboard friendlies = pos.pieces(us) & ~pos.freeze_squares(us);
-          int friendlyCount = popcount(zone & friendlies);
-          return friendlyCount > enemyCount;
+          return impact.friendlyCount > impact.enemyCount;
       }
 
       if (potion == Variant::POTION_JUMP)
@@ -100,6 +98,50 @@ bool MovePicker::is_useless_potion(Move m) const {
   }
 
   return false;
+}
+
+
+bool MovePicker::freeze_impact(Move m, FreezeImpact& impact) const {
+
+  if (!pos.potions_enabled() || !is_gating(m))
+      return false;
+
+  PieceType gatingPiece = gating_type(m);
+  if (gatingPiece == NO_PIECE_TYPE)
+      return false;
+
+  for (int idx = 0; idx < Variant::POTION_TYPE_NB; ++idx)
+  {
+      auto potion = static_cast<Variant::PotionType>(idx);
+      if (pos.potion_piece(potion) != gatingPiece)
+          continue;
+
+      if (potion != Variant::POTION_FREEZE)
+          return false;
+
+      Bitboard zone = pos.freeze_zone_from_square(gating_square(m));
+      Color us = pos.side_to_move();
+      Color them = ~us;
+
+      Bitboard enemyMask = zone & pos.pieces(them) & ~pos.freeze_squares(them);
+      Bitboard friendlyMask = zone & pos.pieces(us) & ~pos.freeze_squares(us);
+
+      impact.enemyCount = popcount(enemyMask);
+      impact.friendlyCount = popcount(friendlyMask);
+      return true;
+  }
+
+  return false;
+}
+
+
+int MovePicker::freeze_net_score(Move m) const {
+
+  FreezeImpact impact;
+  if (!freeze_impact(m, impact))
+      return 0;
+
+  return (impact.enemyCount - impact.friendlyCount) * FreezeNetImpactWeight;
 }
 
 
@@ -158,7 +200,8 @@ void MovePicker::score() {
       if constexpr (Type == CAPTURES)
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
                    + (*gateHistory)[pos.side_to_move()][gating_square(m)]
-                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
+                   + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]
+                   + freeze_net_score(m);
 
       else if constexpr (Type == QUIETS)
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
@@ -167,17 +210,20 @@ void MovePicker::score() {
                    +     (*continuationHistory[1])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[3])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[5])[history_slot(pos.moved_piece(m))][to_sq(m)]
-                   + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0);
+                   + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0)
+                   + freeze_net_score(m);
 
       else // Type == EVASIONS
       {
           if (pos.capture(m))
               m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
-                       - Value(type_of(pos.moved_piece(m)));
+                       - Value(type_of(pos.moved_piece(m)))
+                       + freeze_net_score(m);
           else
               m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
                        + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
-                       - (1 << 28);
+                       - (1 << 28)
+                       + freeze_net_score(m);
       }
 }
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -76,7 +76,7 @@ namespace {
 
             int bonus = 0;
 
-            PieceType kingType = pos.variant()->king_type();
+            PieceType kingType = pos.king_type();
             if (kingType != NO_PIECE_TYPE && pos.count(them, kingType) == 1)
             {
                 Square kingSq = pos.square(them, kingType);

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,7 +146,6 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
-  int freeze_mobility_bonus(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -152,6 +152,10 @@ private:
     int friendlyValue = 0;
     int enemyCount = 0;
     int friendlyCount = 0;
+    int enemyThreatValue = 0;
+    int friendlyThreatValue = 0;
+    int enemyThreatCount = 0;
+    int friendlyThreatCount = 0;
     bool hitsEnemyKing = false;
     bool hitsFriendlyKing = false;
   };

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,7 +146,7 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
-  int potion_inventory_bonus(Move m) const;
+  int freeze_mobility_bonus(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,12 +146,6 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
-  struct FreezeImpact {
-    int enemyCount = 0;
-    int friendlyCount = 0;
-  };
-  bool freeze_impact(Move m, FreezeImpact& impact) const;
-  int freeze_net_score(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,6 +146,7 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
+  int jump_gate_bonus(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,6 +146,7 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
+  int potion_inventory_bonus(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,6 +146,12 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
+  struct FreezeImpact {
+    int enemyCount = 0;
+    int friendlyCount = 0;
+  };
+  bool freeze_impact(Move m, FreezeImpact& impact) const;
+  int freeze_net_score(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -146,7 +146,18 @@ private:
   template<PickType T, typename Pred> Move select(Pred);
   template<GenType> void score();
   bool is_useless_potion(Move m) const;
-  int jump_gate_bonus(Move m) const;
+  Variant::PotionType gating_potion(Move m) const;
+  struct FreezeImpact {
+    int enemyValue = 0;
+    int friendlyValue = 0;
+    int enemyCount = 0;
+    int friendlyCount = 0;
+    bool hitsEnemyKing = false;
+    bool hitsFriendlyKing = false;
+  };
+  int freeze_piece_weight(Piece pc) const;
+  FreezeImpact freeze_impact(Move m) const;
+  int freeze_gate_bonus(Move m) const;
   ExtMove* begin() { return cur; }
   ExtMove* end() { return endMoves; }
 


### PR DESCRIPTION
## Summary
- share freeze impact counting between potion filtering and move ordering
- add net-impact weight to prioritize freezes that hit more enemies than friendlies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab47e2a408322b5da1707abb918fd