### PR TITLE
Silence unused parameter warnings in NNUE variant feature

### DIFF
--- a/src/nnue/features/half_ka_v2_variants.cpp
+++ b/src/nnue/features/half_ka_v2_variants.cpp
@@ -105,7 +105,9 @@ namespace Stockfish::Eval::NNUE::Features {
     return pos.count<ALL_PIECES>();
   }
 
-  bool HalfKAv2Variants::requires_refresh(StateInfo* st, Color perspective, const Position& pos) {
+  bool HalfKAv2Variants::requires_refresh([[maybe_unused]] StateInfo* st,
+                                          [[maybe_unused]] Color perspective,
+                                          [[maybe_unused]] const Position& pos) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- mark HalfKAv2Variants::requires_refresh parameters as [[maybe_unused]] to silence unused warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd77bfb7883228c3a8fd373745353