### PR TITLE
Refine Battle of the Kings move ordering heuristics

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
   pull_request:
     branches:
       - master
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization-s1f0h7 ]
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization-s1f0h7 ]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization-s1f0h7 ]
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization-s1f0h7 ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,12 +5,12 @@ on:
       - master
       - tools
       - github_ci
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
   pull_request:
     branches:
       - master
       - tools
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ on:
     pull_request:
       branches:
         - master
-        - codex/implement-chess-heuristics-for-move-prioritization
+        - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@ on:
     push:
       branches:
         - master
-        - codex/implement-chess-heuristics-for-move-prioritization
+        - codex/implement-chess-heuristics-for-move-prioritization-s1f0h7
     pull_request:
       branches:
         - master

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -16,6 +16,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+#include <array>
 #include <cassert>
 
 #include "movepick.h"
@@ -30,6 +32,307 @@ int history_slot(Piece pc) {
 }
 
 namespace {
+
+  bool is_battle_kings(const Position& pos) {
+    return  pos.gating()
+        && pos.gating_piece_after(WHITE, PAWN)   == KNIGHT
+        && pos.gating_piece_after(WHITE, KNIGHT) == BISHOP
+        && pos.gating_piece_after(WHITE, BISHOP) == ROOK
+        && pos.gating_piece_after(WHITE, ROOK)   == QUEEN
+        && pos.gating_piece_after(WHITE, QUEEN)  == COMMONER
+        && pos.gating_piece_after(BLACK, PAWN)   == KNIGHT
+        && pos.gating_piece_after(BLACK, KNIGHT) == BISHOP
+        && pos.gating_piece_after(BLACK, BISHOP) == ROOK
+        && pos.gating_piece_after(BLACK, ROOK)   == QUEEN
+        && pos.gating_piece_after(BLACK, QUEEN)  == COMMONER;
+  }
+
+  struct BattleKingsContext {
+
+    static constexpr std::array<PieceType, 6> CaptureOrder = {PAWN, KNIGHT, BISHOP, ROOK, QUEEN, COMMONER};
+
+    bool enabled = false;
+    Color us = WHITE;
+    Color them = BLACK;
+    Rank maxRank = RANK_8;
+    int ranks = 0;
+    int files = 0;
+    std::array<int, CaptureOrder.size()> remaining{};
+    int friendlyYoung = 0;
+    int enemyYoung = 0;
+    int youngBalance = 0;
+
+    explicit BattleKingsContext(const Position& pos) {
+      enabled = is_battle_kings(pos);
+      if (!enabled)
+          return;
+
+      us = pos.side_to_move();
+      them = ~us;
+      maxRank = pos.max_rank();
+      ranks = pos.ranks();
+      files = pos.files();
+
+      for (size_t i = 0; i < CaptureOrder.size(); ++i)
+          remaining[i] = pos.count(them, CaptureOrder[i]);
+
+      friendlyYoung = pos.count(us, PAWN) + pos.count(us, KNIGHT) + pos.count(us, BISHOP);
+      enemyYoung = pos.count(them, PAWN) + pos.count(them, KNIGHT) + pos.count(them, BISHOP);
+      youngBalance = friendlyYoung - enemyYoung;
+    }
+
+    int category_index(PieceType pt) const {
+      for (size_t i = 0; i < CaptureOrder.size(); ++i)
+          if (CaptureOrder[i] == pt)
+              return int(i);
+      return -1;
+    }
+
+    int axis_weight(int coord, int dimension) const {
+      if (dimension <= 1)
+          return 0;
+
+      int span = dimension - 1;
+      int diff = 2 * coord - span;
+      if (diff < 0)
+          diff = -diff;
+      return span - diff;
+    }
+
+    int centrality(Square sq) const {
+      if (sq == SQ_NONE)
+          return 0;
+      return axis_weight(file_of(sq), files) + axis_weight(rank_of(sq), ranks);
+    }
+
+    int territory(Square sq) const {
+      if (sq == SQ_NONE || ranks <= 1)
+          return 0;
+
+      int rel = int(relative_rank(us, sq, maxRank));
+      int mid = (ranks - 1) / 2;
+      return rel - mid;
+    }
+
+    int sequential_capture(PieceType victim) const {
+      if (victim == NO_PIECE_TYPE)
+          return 0;
+
+      if (victim == COMMONER)
+          return 10000;
+
+      int idx = category_index(victim);
+      if (idx == -1)
+          return 0;
+
+      for (int earlier = 0; earlier < idx; ++earlier)
+          if (remaining[earlier])
+              return -320 * (idx - earlier) - 60 * remaining[earlier];
+
+      int base = 600 + (int(CaptureOrder.size()) - 1 - idx) * 130;
+      if (remaining[idx] == 1)
+          base += 220;
+      return base;
+    }
+
+    int mover_plan(const Position& pos, Move m, PieceType mover, bool isCapture) const {
+      Square from = from_sq(m);
+      Square to = to_sq(m);
+      int centDiff = centrality(to) - centrality(from);
+      int terrDiff = territory(to) - territory(from);
+      int forwardTo = territory(to);
+      int score = 0;
+
+      switch (mover)
+      {
+      case PAWN:
+          score += 480;
+          score += terrDiff * 220;
+          score += centDiff * 35;
+          if (terrDiff <= 0 && !isCapture)
+              score -= 180;
+          break;
+
+      case KNIGHT:
+          score += 260;
+          score += centDiff * 60;
+          score += std::max(0, forwardTo) * 90;
+          if (pos.count(us, KNIGHT) > pos.count(them, KNIGHT))
+              score += 90;
+          break;
+
+      case BISHOP:
+          score += 150;
+          score += centDiff * 45;
+          score += std::max(0, forwardTo) * 70;
+          break;
+
+      case ROOK:
+          score -= 220;
+          if (isCapture)
+              score += 160;
+          score += centDiff * 20;
+          break;
+
+      case QUEEN:
+          score -= 900;
+          break;
+
+      case COMMONER:
+          score -= 400;
+          break;
+
+      default:
+          break;
+      }
+
+      if (youngBalance < 0 && (mover == PAWN || mover == KNIGHT || mover == BISHOP))
+          score += 180;
+
+      if (youngBalance > 0 && (mover == ROOK || mover == QUEEN))
+          score -= 120;
+
+      return score;
+    }
+
+    int gating_bonus(const Position& pos, Move m) const {
+      PieceType gate = gating_type(m);
+      if (gate == NO_PIECE_TYPE)
+          return 0;
+
+      Square sq = gating_square(m);
+      int cent = centrality(sq);
+      int terr = territory(sq);
+
+      Bitboard enemyAttackers = sq != SQ_NONE ? pos.attackers_to(sq, them) : Bitboard(0);
+      Bitboard friendlyAttackers = sq != SQ_NONE ? pos.attackers_to(sq, us) : Bitboard(0);
+
+      int score = 0;
+      switch (gate)
+      {
+      case KNIGHT:
+          score += 1500;
+          score += cent * 60;
+          score += std::max(0, terr) * 120;
+          score += std::max(0, -youngBalance) * 60;
+          break;
+
+      case BISHOP:
+          score += 1100;
+          score += cent * 55;
+          score += std::max(0, terr) * 90;
+          score += std::max(0, -youngBalance) * 45;
+          break;
+
+      case ROOK:
+          score -= 500;
+          score += cent * 25;
+          break;
+
+      case QUEEN:
+          score -= 1600;
+          break;
+
+      case COMMONER:
+          score -= 5200;
+          break;
+
+      default:
+          break;
+      }
+
+      if (sq != SQ_NONE)
+      {
+          Bitboard occupied = pos.pieces();
+          Square from = from_sq(m);
+          if (from != SQ_NONE)
+              occupied ^= square_bb(from);
+          occupied |= square_bb(to_sq(m));
+          occupied |= square_bb(sq);
+
+          if (gate == KNIGHT || gate == BISHOP)
+          {
+              Bitboard attacks = attacks_bb(us, gate, sq, occupied);
+
+              if (attacks & pos.pieces(them, PAWN))
+                  score += 260;
+
+              if (gate == KNIGHT && (attacks & pos.pieces(them, KNIGHT)))
+                  score += 140;
+
+              if (gate == BISHOP && (attacks & pos.pieces(them, KNIGHT)))
+                  score += 160;
+          }
+      }
+
+      if (enemyAttackers)
+      {
+          int attackers = std::min(3, popcount(enemyAttackers));
+          score -= 200 * attackers;
+          if (!friendlyAttackers)
+              score -= 320;
+      }
+      else
+          score += 120;
+
+      return score;
+    }
+
+    int queen_timing(const Position& pos, Move m, PieceType mover, bool isCapture, PieceType victim) const {
+      if (mover != QUEEN)
+          return 0;
+
+      int score = -900;
+
+      if (!isCapture)
+          score -= 600;
+
+      if (gating_type(m) == COMMONER)
+          score -= 1600;
+
+      if (friendlyYoung <= 2)
+          score /= 2;
+
+      if (remaining[0] || remaining[1] || remaining[2])
+          score -= 360;
+
+      Square from = from_sq(m);
+      if (from != SQ_NONE && pos.attackers_to(from, them))
+          score /= 2;
+
+      if (isCapture)
+      {
+          if (victim == COMMONER)
+              return 12000;
+
+          score += sequential_capture(victim) + 480;
+      }
+
+      return score;
+    }
+
+    int bonus(const Position& pos, Move m) const {
+      if (!enabled)
+          return 0;
+
+      Piece moved = pos.moved_piece(m);
+      PieceType mover = type_of(moved);
+      bool isCapture = pos.capture(m);
+      Piece captured = isCapture ? pos.piece_on(to_sq(m)) : NO_PIECE;
+      PieceType victim = captured != NO_PIECE ? type_of(captured) : NO_PIECE_TYPE;
+
+      int score = 0;
+      score += mover_plan(pos, m, mover, isCapture);
+      score += gating_bonus(pos, m);
+
+      if (isCapture && victim != NO_PIECE_TYPE)
+          score += sequential_capture(victim);
+
+      score += queen_timing(pos, m, mover, isCapture, victim);
+
+      return score;
+    }
+  };
 
   enum Stages {
     MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
@@ -107,13 +410,21 @@ void MovePicker::score() {
 
   static_assert(Type == CAPTURES || Type == QUIETS || Type == EVASIONS, "Wrong type");
 
+  const BattleKingsContext battle(pos);
+
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
+      {
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
                    + (*gateHistory)[pos.side_to_move()][gating_square(m)]
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
 
+          if (battle.enabled)
+              m.value += battle.bonus(pos, m);
+      }
+
       else if constexpr (Type == QUIETS)
+      {
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
                    +     (*gateHistory)[pos.side_to_move()][gating_square(m)]
                    + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
@@ -121,6 +432,10 @@ void MovePicker::score() {
                    +     (*continuationHistory[3])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[5])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0);
+
+          if (battle.enabled)
+              m.value += battle.bonus(pos, m);
+      }
 
       else // Type == EVASIONS
       {


### PR DESCRIPTION
## Summary
- add a BattleKingsContext that tracks the variant state, young piece balance, and capture priorities for Battle of the Kings
- score gating, capture, and queen timing using territory-aware bonuses that reward young development and penalize risky seniors
- apply the refined heuristic inside capture and quiet move ordering whenever the variant is detected

## Testing
- make -C src build ARCH=x86-64 -j2

------
https://chatgpt.com/codex/tasks/task_e_68dcd97993688322a6c8ce3fc3187a54