### PR TITLE
Refine Battle of the Kings move ordering heuristics

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -124,6 +124,13 @@ class MovePicker {
   enum PickType { Next, Best };
 
 public:
+  enum Stages {
+    MAIN_TT, CAPTURE_INIT, GOOD_CAPTURE, REFUTATION, QUIET_INIT, QUIET, BAD_CAPTURE,
+    EVASION_TT, EVASION_INIT, EVASION,
+    PROBCUT_TT, PROBCUT_INIT, PROBCUT,
+    QSEARCH_TT, QCAPTURE_INIT, QCAPTURE, QCHECK_INIT, QCHECK
+  };
+
   MovePicker(const MovePicker&) = delete;
   MovePicker& operator=(const MovePicker&) = delete;
   MovePicker(const Position&, Move, Value, const GateHistory*, const CapturePieceToHistory*);


### PR DESCRIPTION
## Summary
- rebuild the BattleKings move heuristic to account for young/heavy inventories, gating safety, and capture sequencing in the variant
- add territorial, centralization, support, and queen-delay incentives so Battle of the Kings capture and quiet scoring follow the variant strategy
- expose a `battle_kings_adjustment` helper so the contextual heuristic can share the existing move-ordering interface
- publish the MovePicker stage enum in the header and adjust the implementation to reference the class-scoped constants so the build succeeds after rebasing

## Testing
- make -C src build ARCH=x86-64 -j2

------
https://chatgpt.com/codex/tasks/task_e_68dcd97993688322a6c8ce3fc3187a54