### PR TITLE
Improve Battle of Kings move ordering heuristic and enable CI on PRs

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -3,11 +3,8 @@ on:
   push:
     branches:
       - master
-      - codex/implement-chess-heuristics-for-move-prioritization
   pull_request:
-    branches:
-      - master
-      - codex/implement-chess-heuristics-for-move-prioritization
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,12 +5,8 @@ on:
       - master
       - tools
       - github_ci
-      - codex/implement-chess-heuristics-for-move-prioritization
   pull_request:
-    branches:
-      - master
-      - tools
-      - codex/implement-chess-heuristics-for-move-prioritization
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,14 +1,11 @@
 name: Wheels
 
-on: 
+on:
     push:
       branches:
         - master
-        - codex/implement-chess-heuristics-for-move-prioritization
     pull_request:
-      branches:
-        - master
-        - codex/implement-chess-heuristics-for-move-prioritization
+      types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build_wheels:


### PR DESCRIPTION
## Summary
- update all GitHub Actions workflows to run for every pull request and remove hard-coded branch filters
- expand the Battle of the Kings move picker adjustments with territory, centralisation, and gating balance heuristics for better move ordering

## Testing
- `cd src && make build -j2 ARCH=x86-64`


------
https://chatgpt.com/codex/tasks/task_e_68dcff0a954883228b4d5befddb1559f