### PR TITLE
Improve Battle of the Kings heuristics and enable CI triggers

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -2,12 +2,10 @@ name: fairy
 on:
   push:
     branches:
-      - master
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - '**'
   pull_request:
     branches:
-      - master
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - '**'
 jobs:
   fairy:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,11 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches:
+      - '**'
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches:
+      - '**'
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,11 @@ name: Release
 
 on:
   push:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches:
+      - '**'
   pull_request:
-    branches: [ master, codex/implement-chess-heuristics-for-move-prioritization ]
+    branches:
+      - '**'
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -2,15 +2,10 @@ name: Stockfish
 on:
   push:
     branches:
-      - master
-      - tools
-      - github_ci
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - '**'
   pull_request:
     branches:
-      - master
-      - tools
-      - codex/implement-chess-heuristics-for-move-prioritization
+      - '**'
 jobs:
   Stockfish:
     name: ${{ matrix.config.name }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,14 +1,12 @@
 name: Wheels
 
-on: 
+on:
     push:
       branches:
-        - master
-        - codex/implement-chess-heuristics-for-move-prioritization
+        - '**'
     pull_request:
       branches:
-        - master
-        - codex/implement-chess-heuristics-for-move-prioritization
+        - '**'
 
 jobs:
   build_wheels:


### PR DESCRIPTION
## Summary
- enable every GitHub Actions workflow to run for all branches and pull requests so new PRs are automatically checked
- refine Battle of the Kings move ordering by adding territory, stage-balance, and centrality-aware bonuses for gating, movement, and captures

## Testing
- make build ARCH=x86-64-modern -j2

------
https://chatgpt.com/codex/tasks/task_e_68dcff0a954883228b4d5befddb1559f