### PR TITLE
Disable repetition-based draws in Battlekings variant

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -788,8 +788,7 @@ namespace {
         }
         v->stalemateValue = -VALUE_MATE;
         v->nMoveRule = 0;
-        v->nFoldRule = 2;
-        v->nFoldValue = VALUE_MATE;
+        v->nFoldRule = 0;
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(COMMONER);
         v->extinctionMustAppear = piece_set(COMMONER);


### PR DESCRIPTION
## Summary
- disable the n-fold repetition rule for Battlekings so repeated positions no longer lead to draws

## Testing
- python3 test.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a7bc45a08322a86317874d577c8b