### PR TITLE
Add Kings or Lemmings variant fixes

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -169,8 +169,8 @@ constexpr Bitboard make_bitboard(Square s, Squares... squares) {
 }
 
 inline Bitboard square_bb(Square s) {
-  assert(is_ok(s));
-  return SquareBB[s];
+  assert(s == SQ_NONE || is_ok(s));
+  return s == SQ_NONE ? Bitboard(0) : SquareBB[s];
 }
 
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -514,6 +514,7 @@ Variant* VariantParser<DoCheck>::parse(Variant* v) {
     parse_attribute("extinctionValue", v->extinctionValue);
     parse_attribute("extinctionClaim", v->extinctionClaim);
     parse_attribute("extinctionPseudoRoyal", v->extinctionPseudoRoyal);
+    parse_attribute("extinctionFirstCapture", v->extinctionFirstCapture);
     parse_attribute("dupleCheck", v->dupleCheck);
     // extinction piece types
     parse_attribute("extinctionPieceTypes", v->extinctionPieceTypes, v->pieceToChar);

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -925,6 +925,9 @@ Bitboard Position::slider_blockers(Bitboard sliders, Square s, Bitboard& pinners
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard janggiCannons) const {
 
+  if (s == SQ_NONE)
+      return Bitboard(0);
+
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
   {
@@ -999,6 +1002,8 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
 
 
 Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
+  if (s == SQ_NONE)
+      return Bitboard(0);
   return attackers_to(s, occupied, WHITE) | attackers_to(s, occupied, BLACK);
 }
 
@@ -2751,6 +2756,16 @@ bool Position::is_optional_game_end(Value& result, int ply, int countStarted) co
 /// It does not detect stalemates.
 
 bool Position::is_immediate_game_end(Value& result, int ply) const {
+
+  if (   extinction_first_capture()
+      && extinction_value() != VALUE_NONE
+      && st->capturedPiece != NO_PIECE
+      && (extinction_piece_types() & type_of(st->capturedPiece)))
+  {
+      Color victim = color_of(st->capturedPiece);
+      result = victim == sideToMove ? extinction_value(ply) : -extinction_value(ply);
+      return true;
+  }
 
   // Extinction
   // Extinction does not apply for pseudo-royal pieces, because they can not be captured

--- a/src/position.h
+++ b/src/position.h
@@ -790,7 +790,7 @@ inline Bitboard Position::drop_region(Color c, PieceType pt) const {
           else
           {
               assert(enclosing_drop() == ATAXX);
-              Bitboard ours = pieces(c);
+              Bitboard ours = pieces(c, variant()->enclosingDropAdjacencyType);
               b &=  shift<NORTH     >(ours) | shift<SOUTH     >(ours)
                   | shift<NORTH_EAST>(ours) | shift<SOUTH_WEST>(ours)
                   | shift<EAST      >(ours) | shift<WEST      >(ours)

--- a/src/position.h
+++ b/src/position.h
@@ -209,6 +209,7 @@ public:
   int extinction_piece_count() const;
   int extinction_opponent_piece_count() const;
   bool extinction_pseudo_royal() const;
+  bool extinction_first_capture() const;
   PieceType flag_piece(Color c) const;
   Bitboard flag_region(Color c) const;
   bool flag_move() const;
@@ -1036,6 +1037,11 @@ inline bool Position::extinction_pseudo_royal() const {
   return var->extinctionPseudoRoyal;
 }
 
+inline bool Position::extinction_first_capture() const {
+  assert(var != nullptr);
+  return var->extinctionFirstCapture;
+}
+
 inline PieceType Position::flag_piece(Color c) const {
   assert(var != nullptr);
   return var->flagPiece[c];
@@ -1237,9 +1243,16 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
   return lsb(pieces(c, Pt));
 }
 
+template<> inline Square Position::square<KING>(Color c) const {
+  assert(count<KING>(c) <= 1);
+  return count<KING>(c) ? lsb(pieces(c, KING)) : SQ_NONE;
+}
+
 inline Square Position::square(Color c, PieceType pt) const {
-  assert(count(c, pt) == 1);
-  return lsb(pieces(c, pt));
+  int n = count(c, pt);
+  assert(pt != KING || n <= 1);
+  assert(pt == KING || n == 1);
+  return n ? lsb(pieces(c, pt)) : SQ_NONE;
 }
 
 inline Bitboard Position::ep_squares() const {
@@ -1343,15 +1356,15 @@ inline Bitboard Position::moves_from(Color c, PieceType pt, Square s) const {
 }
 
 inline Bitboard Position::attackers_to(Square s) const {
-  return attackers_to(s, pieces());
+  return s == SQ_NONE ? Bitboard(0) : attackers_to(s, pieces());
 }
 
 inline Bitboard Position::attackers_to(Square s, Color c) const {
-  return attackers_to(s, byTypeBB[ALL_PIECES], c);
+  return s == SQ_NONE ? Bitboard(0) : attackers_to(s, byTypeBB[ALL_PIECES], c);
 }
 
 inline Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c) const {
-  return attackers_to(s, occupied, c, byTypeBB[JANGGI_CANNON]);
+  return s == SQ_NONE ? Bitboard(0) : attackers_to(s, occupied, c, byTypeBB[JANGGI_CANNON]);
 }
 
 inline Bitboard Position::checkers() const {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -745,13 +745,16 @@ namespace {
         v->add_piece(COMMONER, 'k');
         v->castling = false;
         v->checking = false;
+        v->pocketSize = 16;
         v->pieceDrops = true;
         v->enclosingDrop = ATAXX;
-        v->freeDrops = true;
+        v->enclosingDropAdjacencyType = COMMONER;
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(COMMONER);
         v->extinctionFirstCapture = true;
-        v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+        v->pieceValue[MG][COMMONER] = -100;
+        v->pieceValue[EG][COMMONER] = -100;
+        v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[KKKKKKKKKKKKKKKKkkkkkkkkkkkkkkkk] w - - 0 1";
         return v;
     }
     // S-House

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -737,6 +737,23 @@ namespace {
         v->promotionPieceTypes[BLACK] = piece_set(ARCHBISHOP) | CHANCELLOR | QUEEN | ROOK | BISHOP | KNIGHT;
         return v;
     }
+    // Kings or Lemmings
+    // Players duplicate commoners adjacent to an existing one and the first capture wins.
+    Variant* kingsorlemmings_variant() {
+        Variant* v = chess_variant_base()->init();
+        v->remove_piece(KING);
+        v->add_piece(COMMONER, 'k');
+        v->castling = false;
+        v->checking = false;
+        v->pieceDrops = true;
+        v->enclosingDrop = ATAXX;
+        v->freeDrops = true;
+        v->extinctionValue = -VALUE_MATE;
+        v->extinctionPieceTypes = piece_set(COMMONER);
+        v->extinctionFirstCapture = true;
+        v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+        return v;
+    }
     // S-House
     // A hybrid variant of S-Chess and Crazyhouse.
     // Pieces in the pocket can either be gated or dropped.
@@ -1887,6 +1904,8 @@ void VariantMap::init() {
     add("placement", placement_variant());
     add("sittuyin", sittuyin_variant());
     add("seirawan", seirawan_variant());
+    add("kingsorlemmings", kingsorlemmings_variant());
+    add("lemmings", kingsorlemmings_variant());
     add("shouse", shouse_variant());
     add("dragon", dragon_variant());
     add("paradigm", paradigm_variant());

--- a/src/variant.h
+++ b/src/variant.h
@@ -137,6 +137,7 @@ struct Variant {
   Value extinctionValue = VALUE_NONE;
   bool extinctionClaim = false;
   bool extinctionPseudoRoyal = false;
+  bool extinctionFirstCapture = false;
   bool dupleCheck = false;
   PieceSet extinctionPieceTypes = NO_PIECE_SET;
   int extinctionPieceCount = 0;

--- a/src/variant.h
+++ b/src/variant.h
@@ -96,6 +96,7 @@ struct Variant {
   bool firstRankPawnDrops = false;
   bool promotionZonePawnDrops = false;
   EnclosingRule enclosingDrop = NO_ENCLOSING;
+  PieceType enclosingDropAdjacencyType = ALL_PIECES;
   Bitboard enclosingDropStart = 0;
   Bitboard dropRegion[COLOR_NB] = {AllSquares, AllSquares};
   bool sittuyinRookDrop = false;

--- a/test.py
+++ b/test.py
@@ -461,19 +461,27 @@ class TestPyffish(unittest.TestCase):
     def test_kingsorlemmings(self):
         start_fen = sf.start_fen("kingsorlemmings")
         self.assertTrue(start_fen.startswith("rnbqkbnr/pppppppp"))
+        self.assertIn("[", start_fen)
+        pocket = start_fen.split("[", 1)[1].split("]", 1)[0]
+        self.assertEqual(len(pocket), 32)
+        self.assertEqual(pocket.count("K"), 16)
+        self.assertEqual(pocket.count("k"), 16)
+        self.assertTrue(set(pocket) <= {"K", "k"})
 
         moves = ["e2e4"]
         legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
-        self.assertIn("K@e6", legal)
+        self.assertTrue(all('@' not in m for m in legal))
 
         moves = ["e2e4", "e7e5"]
         legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
         self.assertIn("K@e2", legal)
         self.assertNotIn("K@h1", legal)
+        self.assertTrue(all(len(m) < 2 or m[1] != '@' or m[0] == 'K' for m in legal))
 
         moves = ["e2e4", "e7e5", "K@e2"]
         legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
-        self.assertIn("a7a6", legal)
+        self.assertIn("K@e7", legal)
+        self.assertTrue(any(len(m) > 2 and m[1] == '@' for m in legal))
 
     def test_get_fen(self):
         result = sf.get_fen("chess", CHESS, [])

--- a/test.py
+++ b/test.py
@@ -458,6 +458,23 @@ class TestPyffish(unittest.TestCase):
         result = sf.legal_moves("shako", "c8c/ernbqkbnre/pppppppppp/10/10/10/10/PPPPPPPPPP/RR3K4/10 w Qkq - 0 1", [])
         self.assertIn("f2d2", result)
 
+    def test_kingsorlemmings(self):
+        start_fen = sf.start_fen("kingsorlemmings")
+        self.assertTrue(start_fen.startswith("rnbqkbnr/pppppppp"))
+
+        moves = ["e2e4"]
+        legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
+        self.assertIn("K@e6", legal)
+
+        moves = ["e2e4", "e7e5"]
+        legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
+        self.assertIn("K@e2", legal)
+        self.assertNotIn("K@h1", legal)
+
+        moves = ["e2e4", "e7e5", "K@e2"]
+        legal = sf.legal_moves("kingsorlemmings", start_fen, moves)
+        self.assertIn("a7a6", legal)
+
     def test_get_fen(self):
         result = sf.get_fen("chess", CHESS, [])
         self.assertEqual(result, CHESS)


### PR DESCRIPTION
## Summary
- add the Kings or Lemmings variant with commoner drops and first-capture win condition
- harden king lookup and attacker utilities to tolerate missing kings
- plumb the new extinction-first-capture rule through the parser and position logic
- cover the new variant with regression tests

## Testing
- python3 test.py

------
https://chatgpt.com/codex/tasks/task_e_68ecc3014da8832285e0221ab79d7d75