### PR TITLE
Refine battlekings move heuristics and enable CI for work branch

### DIFF
--- a/.github/workflows/fairy.yml
+++ b/.github/workflows/fairy.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - master
+      - work
   pull_request:
+    branches:
+      - master
+      - work
 
 jobs:
   fairy:

--- a/.github/workflows/ffishjs.yml
+++ b/.github/workflows/ffishjs.yml
@@ -2,9 +2,9 @@ name: ffishjs
 
 on:
   push:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
   pull_request:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
 
 env:
   EM_VERSION: 1.39.16

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/rewrite-battlekings-heuristics-from-scratch ]
   pull_request:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/rewrite-battlekings-heuristics-from-scratch ]
 
 jobs:
   windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
   pull_request:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, work ]
 
 jobs:
   windows:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,7 +5,13 @@ on:
       - master
       - tools
       - github_ci
+      - work
   pull_request:
+    branches:
+      - master
+      - tools
+      - github_ci
+      - work
 
 jobs:
   Stockfish:

--- a/.github/workflows/stockfish.yml
+++ b/.github/workflows/stockfish.yml
@@ -5,13 +5,13 @@ on:
       - master
       - tools
       - github_ci
-      - work
+      - codex/rewrite-battlekings-heuristics-from-scratch
   pull_request:
     branches:
       - master
       - tools
       - github_ci
-      - work
+      - codex/rewrite-battlekings-heuristics-from-scratch
 
 jobs:
   Stockfish:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,14 @@
 name: Wheels
 
-on: 
+on:
     push:
       branches:
         - master
+        - work
     pull_request:
+      branches:
+        - master
+        - work
 
 
 jobs:

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -45,65 +45,75 @@ namespace {
         && pos.gating_piece_after(BLACK, QUEEN)  == COMMONER;
   }
 
-  int battle_kings_mover_bonus(PieceType pt) {
+  int battle_kings_piece_youngness(PieceType pt) {
     switch (pt)
     {
-    case PAWN:     return 900;
-    case KNIGHT:   return 600;
-    case BISHOP:   return 400;
-    case ROOK:     return -600;
-    case QUEEN:    return -2000;
-    case COMMONER: return -800;
+    case PAWN:     return 600;
+    case KNIGHT:   return 420;
+    case BISHOP:   return 260;
+    case ROOK:     return 120;
+    case QUEEN:    return -180;
+    case COMMONER: return -4200;
     default:       return 0;
     }
   }
 
-  int battle_kings_gate_bonus(PieceType pt) {
-    switch (pt)
-    {
-    case KNIGHT:   return 1000;
-    case BISHOP:   return 700;
-    case ROOK:     return -500;
-    case QUEEN:    return -1500;
-    case COMMONER: return -4000;
-    default:       return 0;
-    }
+  int battle_kings_board_youngness(const Position& pos, Color c) {
+    int score = 0;
+    score += popcount(pos.pieces(c, PAWN))     * battle_kings_piece_youngness(PAWN);
+    score += popcount(pos.pieces(c, KNIGHT))   * battle_kings_piece_youngness(KNIGHT);
+    score += popcount(pos.pieces(c, BISHOP))   * battle_kings_piece_youngness(BISHOP);
+    score += popcount(pos.pieces(c, ROOK))     * battle_kings_piece_youngness(ROOK);
+    score += popcount(pos.pieces(c, QUEEN))    * battle_kings_piece_youngness(QUEEN);
+    score += popcount(pos.pieces(c, COMMONER)) * battle_kings_piece_youngness(COMMONER);
+    return score;
   }
 
-  int battle_kings_capture_bonus(PieceType pt) {
-    switch (pt)
-    {
-    case COMMONER: return 9000;
-    case PAWN:     return 5000;
-    case KNIGHT:   return 3200;
-    case BISHOP:   return 2200;
-    case ROOK:     return 1200;
-    case QUEEN:    return 600;
-    default:       return 0;
-    }
+  Square battle_kings_capture_square(const Position& pos, Move m) {
+    return type_of(m) == EN_PASSANT ? pos.capture_square(to_sq(m)) : to_sq(m);
   }
 
   int battle_kings_adjustment(const Position& pos, Move m) {
+    Color us = pos.side_to_move();
+    Color them = ~us;
+
+    int myYoungness = battle_kings_board_youngness(pos, us);
+    int theirYoungness = battle_kings_board_youngness(pos, them);
+    int youngnessBalance = myYoungness - theirYoungness;
+
     int bonus = 0;
 
-    PieceType mover = type_of(pos.moved_piece(m));
-    bonus += battle_kings_mover_bonus(mover);
+    Piece moved = pos.moved_piece(m);
+    if (moved != NO_PIECE)
+        bonus += battle_kings_piece_youngness(type_of(moved)) / 4;
 
     if (PieceType gate = gating_type(m); gate != NO_PIECE_TYPE)
-        bonus += battle_kings_gate_bonus(gate);
+    {
+        int gateValue = battle_kings_piece_youngness(gate);
+        bonus += gateValue;
+
+        if (gateValue <= 0)
+            bonus += gateValue; // Double the penalty when spawning old pieces
+    }
 
     if (pos.capture(m))
     {
-        Piece captured = pos.piece_on(to_sq(m));
+        Square captureSq = battle_kings_capture_square(pos, m);
+        Piece captured = pos.piece_on(captureSq);
         if (captured != NO_PIECE)
         {
-            PieceType victim = type_of(captured);
-            bonus += battle_kings_capture_bonus(victim);
-
-            if (mover == QUEEN && victim != COMMONER)
-                bonus -= 2500;
+            int victimValue = battle_kings_piece_youngness(type_of(captured));
+            if (victimValue > 0)
+                bonus += victimValue + victimValue / 2;
+            else
+                bonus += victimValue / 3;
         }
     }
+
+    if (bonus > 0 && youngnessBalance < 0)
+        bonus += (-youngnessBalance) / 4;
+    else if (bonus < 0 && youngnessBalance > 0)
+        bonus -= youngnessBalance / 4;
 
     return bonus;
   }


### PR DESCRIPTION
## Summary
- replace the Battle Kings move-ordering heuristic with a youngness-based evaluation that rewards keeping our pieces youthful and punishes spawning older gates
- leverage the board-wide youngness balance to scale capture and gating priorities, including en-passant handling for accurate victim detection
- allow the existing CI workflows to run for pushes and pull requests involving the `work` branch

## Testing
- `python3 -m unittest test.TestPyFish.test_battlekings_gating_sequence test.TestPyFish.test_battlekings_capture_first_commoner_wins` *(fails: ModuleNotFoundError: No module named 'pyffish')*


------
https://chatgpt.com/codex/tasks/task_e_68ee1fc2e52483229b9d1ded1a1ef03f