### PR TITLE
Fix battlekings gating when capturing commoners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine ]
   pull_request:
-    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn ]
+    branches: [ master, implement-battle-of-the-kings-variant-7bhqbn, codex/fix-illegal-move-in-battlekings-engine ]
 
 jobs:
   windows:

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -599,9 +599,9 @@ void Position::set_check_info(StateInfo* si) const {
       {
           PieceType pt = pop_lsb(ps);
           si->pseudoRoyalCandidates |= pieces(pt);
-          if (count(sideToMove, pt) <= var->extinctionPieceCount + 1)
+          if (extinction_first_capture() || count(sideToMove, pt) <= var->extinctionPieceCount + 1)
               si->pseudoRoyals |= pieces(sideToMove, pt);
-          if (count(~sideToMove, pt) <= var->extinctionPieceCount + 1)
+          if (extinction_first_capture() || count(~sideToMove, pt) <= var->extinctionPieceCount + 1)
               si->pseudoRoyals |= pieces(~sideToMove, pt);
       }
   }
@@ -1284,7 +1284,24 @@ bool Position::legal(Move m) const {
           attackers &= ~SquareBB[capture_square(to)];
 
       if (attackers)
-          return false;
+      {
+          bool captureEndsGame = false;
+
+          if (   extinction_first_capture()
+              && capture(m))
+          {
+              Square captureSq = type_of(m) == EN_PASSANT ? capture_square(to) : to;
+              Piece captured = piece_on(captureSq);
+
+              if (   captured != NO_PIECE
+                  && color_of(captured) == ~us
+                  && (extinction_piece_types() & piece_set(type_of(captured))))
+                  captureEndsGame = true;
+          }
+
+          if (!captureEndsGame)
+              return false;
+      }
   }
 
   // Flying general rule and bikjang

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -792,7 +792,7 @@ namespace {
         v->extinctionValue = -VALUE_MATE;
         v->extinctionPieceTypes = piece_set(COMMONER);
         v->extinctionMustAppear = piece_set(COMMONER);
-     //   v->extinctionPseudoRoyal = true;
+        v->extinctionPseudoRoyal = true;
         v->extinctionFirstCaptureWins = true;
         return v;
     }

--- a/test.py
+++ b/test.py
@@ -471,6 +471,24 @@ class TestPyffish(unittest.TestCase):
         moves = sf.legal_moves("battlekings", fen, [])
         self.assertIn("a2b2", moves)
 
+    def test_battlekings_commoner_capture_ends_game_even_if_gate_attacked(self):
+        fen = "B1B1BB1q/qqBBRQqq/RB1qRBqQ/qRBqqB1R/QqqQqB1R/Rqqqqq1q/qkkqqqqq/kqqrq1br b - - 0 64"
+
+        moves = sf.legal_moves("battlekings", fen, [])
+        self.assertNotIn("b2a3", moves)
+
+        white_to_move = "B1B1BB1q/qqBBRQqq/RB1qRBqQ/qRBqqB1R/QqqQqB1R/kqqqqq1q/q1kqqqqq/kqqrq1br w - - 0 65"
+        white_moves = sf.legal_moves("battlekings", white_to_move, [])
+        self.assertIn("a4a3", white_moves)
+
+        self._check_immediate_game_end(
+            "battlekings",
+            white_to_move,
+            ["a4a3"],
+            True,
+            -sf.VALUE_MATE,
+        )
+
     def test_legal_moves(self):
         fen = "10/10/10/10/10/k9/10/K9 w - - 0 1"
         result = sf.legal_moves("capablanca", fen, [])


### PR DESCRIPTION
## Summary
- mark battlekings commoners as pseudo-royal and treat extinction-first-capture pieces as pseudo-royals regardless of count
- allow gating moves that immediately win by first capture to bypass gate-square attack restrictions
- add a regression test covering the illegal commoner move and winning queen capture scenario

## Testing
- python -m unittest test.TestPyffish.test_battlekings_commoner_capture_ends_game_even_if_gate_attacked

------
https://chatgpt.com/codex/tasks/task_e_68f68af740c48322a6acc4499aeaa3d0