### PR TITLE
Fix battlekings score bug: eval inflation and SEE pruning

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1622,10 +1622,10 @@ Value Eval::evaluate(const Position& pos) {
 
          // Cap scale to prevent eval inflation in variants with unusual piece values
          // or extinction rules (e.g., battlekings) where large material can cause runaway RL.
-         // Use a lower cap (700) to deflate eval and prevent hitting the TB_WIN clamp ceiling,
+         // Use a lower cap (500) to deflate eval and prevent hitting the TB_WIN clamp ceiling,
          // which would cause eval to get stuck at 15147cp in winning positions.
          if (pos.extinction_first_capture())
-             scale = std::min(scale, 700);
+             scale = std::min(scale, 500);
 
          Value nnue = NNUE::evaluate(pos, true) * scale / 1024;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1621,9 +1621,11 @@ Value Eval::evaluate(const Position& pos) {
                      + 32 * pos.non_pawn_material() / 1024;
 
          // Cap scale to prevent eval inflation in variants with unusual piece values
-         // or extinction rules (e.g., battlekings) where large material can cause runaway RL
+         // or extinction rules (e.g., battlekings) where large material can cause runaway RL.
+         // Use a lower cap (700) to deflate eval and prevent hitting the TB_WIN clamp ceiling,
+         // which would cause eval to get stuck at 15147cp in winning positions.
          if (pos.extinction_first_capture())
-             scale = std::min(scale, 1024);
+             scale = std::min(scale, 700);
 
          Value nnue = NNUE::evaluate(pos, true) * scale / 1024;
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1620,6 +1620,11 @@ Value Eval::evaluate(const Position& pos) {
                      + 32 * pos.count<PAWN>()
                      + 32 * pos.non_pawn_material() / 1024;
 
+         // Cap scale to prevent eval inflation in variants with unusual piece values
+         // or extinction rules (e.g., battlekings) where large material can cause runaway RL
+         if (pos.extinction_first_capture())
+             scale = std::min(scale, 1024);
+
          Value nnue = NNUE::evaluate(pos, true) * scale / 1024;
 
          if (pos.is_chess960())

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1162,7 +1162,8 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // SEE based pruning
-              if (!pos.see_ge(move, Value(-218 - 120 * pos.captures_to_hand()) * depth)) // (~25 Elo)
+              // Skip for extinction_first_capture variants where SEE may be unreliable
+              if (!pos.extinction_first_capture() && !pos.see_ge(move, Value(-218 - 120 * pos.captures_to_hand()) * depth)) // (~25 Elo)
                   continue;
           }
           else
@@ -1185,7 +1186,8 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Prune moves with negative SEE (~20 Elo)
-              if (!(pos.walling_rule() == DUCK) && !pos.see_ge(move, Value(-(30 - std::min(lmrDepth, 18) + 10 * !!pos.flag_region(pos.side_to_move())) * lmrDepth * lmrDepth)))
+              // Skip for duck chess and extinction_first_capture variants where SEE may be unreliable
+              if (!(pos.walling_rule() == DUCK) && !pos.extinction_first_capture() && !pos.see_ge(move, Value(-(30 - std::min(lmrDepth, 18) + 10 * !!pos.flag_region(pos.side_to_move())) * lmrDepth * lmrDepth)))
                   continue;
           }
       }
@@ -1662,7 +1664,8 @@ moves_loop: // When in check, search starts from here
               continue;
           }
 
-          if (futilityBase <= alpha && !pos.see_ge(move, VALUE_ZERO + 1))
+          // Skip SEE check for extinction_first_capture variants where SEE may be unreliable
+          if (!pos.extinction_first_capture() && futilityBase <= alpha && !pos.see_ge(move, VALUE_ZERO + 1))
           {
               bestValue = std::max(bestValue, futilityBase);
               continue;
@@ -1670,7 +1673,9 @@ moves_loop: // When in check, search starts from here
       }
 
       // Do not search moves with negative SEE values
+      // Skip for extinction_first_capture variants where SEE may be unreliable
       if (    bestValue > VALUE_TB_LOSS_IN_MAX_PLY
+          && !pos.extinction_first_capture()
           && !pos.see_ge(move))
           continue;
 


### PR DESCRIPTION
- Cap NNUE scale factor to 1024 for extinction_first_capture variants to prevent eval inflation when material is high (fixes 15147cp stuck eval)
- Disable SEE-based pruning for extinction_first_capture variants where SEE is unreliable due to unusual piece values and game rules (captures can immediately end the game)

These changes address eval getting stuck at 15147cp (31506 internal) and improve move selection in won positions.