### PR TITLE
Exp1 opt02 cache boardbb

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -616,6 +616,7 @@ void Position::set_check_info(StateInfo* si) const {
 void Position::set_state(StateInfo* si) const {
 
   si->key = si->materialKey = 0;
+  si->boardBB = board_size_bb(var->maxFile, var->maxRank) & ~si->wallSquares;
   si->pawnKey = Zobrist::noPawns;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->checkersBB = count<KING>(sideToMove) ? attackers_to(square<KING>(sideToMove), ~sideToMove) : Bitboard(0);
@@ -2080,6 +2081,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       byTypeBB[ALL_PIECES] |= gating_square(m);
       k ^= Zobrist::wall[gating_square(m)];
   }
+
+  st->boardBB = board_size_bb(var->maxFile, var->maxRank) & ~st->wallSquares;
 
   // Update the key with the final value
   st->key = k;

--- a/src/position.h
+++ b/src/position.h
@@ -59,6 +59,7 @@ struct StateInfo {
 
   // Not copied when making a move (will be recomputed anyhow)
   Key        key;
+  Bitboard   boardBB;
   Bitboard   checkersBB;
   Piece      unpromotedCapturedPiece;
   Piece      unpromotedBycatch[SQUARE_NB];
@@ -424,7 +425,7 @@ inline bool Position::two_boards() const {
 
 inline Bitboard Position::board_bb() const {
   assert(var != nullptr);
-  return board_size_bb(var->maxFile, var->maxRank) & ~st->wallSquares;
+  return st->boardBB;
 }
 
 inline Bitboard Position::board_bb(Color c, PieceType pt) const {


### PR DESCRIPTION
## Summary
  - Cache `board_bb()` in `StateInfo` and reuse it from `Position::board_bb()`.

  ## Technical details
  - Add `StateInfo::boardBB` and compute it in `set_state()` as `board_size_bb(...) & ~wallSquares`.
  - Update `boardBB` after walling/gating changes in `do_move()`, so `board_bb()` becomes a constant-time accessor.

  ## Performance
  - bench (nodes/s vs baseline): chess 332059 → 333760 (+0.5%).
  - Baseline is `stockfish_base.exe` from the perf log; deltas are incremental on top of prior accepted optimizations.

  ## Tests
  - tests/protocol.sh
  - tests/perft.sh chess
  - tests/regression.sh chess capablanca xiangqi shogi