### PR TITLE
Cache pieces/king square in gives_check

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1432,7 +1432,10 @@ bool Position::gives_check(Move m) const {
   if (!count<KING>(~sideToMove))
       return false;
 
-  Bitboard occupied = (type_of(m) != DROP ? pieces() ^ from : pieces()) | to;
+  const Square ksq = square<KING>(~sideToMove);
+  const Bitboard ksqBB = square_bb(ksq);
+  const Bitboard piecesAll = pieces();
+  Bitboard occupied = (type_of(m) != DROP ? piecesAll ^ from : piecesAll) | to;
   Bitboard janggiCannons = pieces(JANGGI_CANNON);
   if (type_of(moved_piece(m)) == JANGGI_CANNON)
       janggiCannons = (type_of(m) == DROP ? janggiCannons : janggiCannons ^ from) | to;
@@ -1446,12 +1449,12 @@ bool Position::gives_check(Move m) const {
       PieceType pt = type_of(moved_piece(m));
       if (pt == JANGGI_CANNON)
       {
-          if (attacks_bb(sideToMove, pt, to, occupied) & attacks_bb(sideToMove, pt, to, occupied & ~janggiCannons) & square<KING>(~sideToMove))
+          if (attacks_bb(sideToMove, pt, to, occupied) & attacks_bb(sideToMove, pt, to, occupied & ~janggiCannons) & ksqBB)
               return true;
       }
       else if (AttackRiderTypes[pt] & (HOPPING_RIDERS | ASYMMETRICAL_RIDERS))
       {
-          if (attacks_bb(sideToMove, pt, to, occupied) & square<KING>(~sideToMove))
+          if (attacks_bb(sideToMove, pt, to, occupied) & ksqBB)
               return true;
       }
       else if (check_squares(pt) & to)
@@ -1460,12 +1463,12 @@ bool Position::gives_check(Move m) const {
 
   // Is there a discovered check?
   if (  ((type_of(m) != DROP && (blockers_for_king(~sideToMove) & from)) || (non_sliding_riders() & pieces(sideToMove)))
-      && attackers_to(square<KING>(~sideToMove), occupied, sideToMove, janggiCannons) & occupied)
+      && attackers_to(ksq, occupied, sideToMove, janggiCannons) & occupied)
       return true;
 
   // Is there a check by gated pieces?
   if (    is_gating(m)
-      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (pieces() ^ from) | to) & square<KING>(~sideToMove))
+      && attacks_bb(sideToMove, gating_type(m), gating_square(m), (piecesAll ^ from) | to) & ksqBB)
       return true;
 
   // Petrified piece can't give check
@@ -1473,15 +1476,15 @@ bool Position::gives_check(Move m) const {
       return false;
 
   // Is there a check by special diagonal moves?
-  if (more_than_one(diagonal_lines() & (to | square<KING>(~sideToMove))))
+  if (more_than_one(diagonal_lines() & (to | ksqBB)))
   {
       PieceType pt = type_of(moved_piece(m));
       PieceType diagType = pt == WAZIR ? FERS : pt == SOLDIER ? PAWN : pt == ROOK ? BISHOP : NO_PIECE_TYPE;
-      if (diagType && (attacks_bb(sideToMove, diagType, to, occupied) & square<KING>(~sideToMove)))
+      if (diagType && (attacks_bb(sideToMove, diagType, to, occupied) & ksqBB))
           return true;
       else if (pt == JANGGI_CANNON && (  rider_attacks_bb<RIDER_CANNON_DIAG>(to, occupied)
                                        & rider_attacks_bb<RIDER_CANNON_DIAG>(to, occupied & ~janggiCannons)
-                                       & square<KING>(~sideToMove)))
+                                       & ksqBB))
           return true;
   }
 
@@ -1493,13 +1496,13 @@ bool Position::gives_check(Move m) const {
       return false;
 
   case PROMOTION:
-      return attacks_bb(sideToMove, promotion_type(m), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, promotion_type(m), to, piecesAll ^ from) & ksqBB;
 
   case PIECE_PROMOTION:
-      return attacks_bb(sideToMove, promoted_piece_type(type_of(moved_piece(m))), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, promoted_piece_type(type_of(moved_piece(m))), to, piecesAll ^ from) & ksqBB;
 
   case PIECE_DEMOTION:
-      return attacks_bb(sideToMove, type_of(unpromoted_piece_on(from)), to, pieces() ^ from) & square<KING>(~sideToMove);
+      return attacks_bb(sideToMove, type_of(unpromoted_piece_on(from)), to, piecesAll ^ from) & ksqBB;
 
   // En passant capture with check? We have already handled the case
   // of direct checks and ordinary discovered check, so the only case we
@@ -1508,9 +1511,9 @@ bool Position::gives_check(Move m) const {
   case EN_PASSANT:
   {
       Square capsq = capture_square(to);
-      Bitboard b = (pieces() ^ from ^ capsq) | to;
+      Bitboard b = (piecesAll ^ from ^ capsq) | to;
 
-      return attackers_to(square<KING>(~sideToMove), b) & pieces(sideToMove) & b;
+      return attackers_to(ksq, b) & pieces(sideToMove) & b;
   }
   default: //CASTLING
   {
@@ -1523,11 +1526,11 @@ bool Position::gives_check(Move m) const {
       // Is there a discovered check?
       if (   castling_rank(WHITE) > RANK_1
           && ((blockers_for_king(~sideToMove) & rfrom) || (non_sliding_riders() & pieces(sideToMove)))
-          && attackers_to(square<KING>(~sideToMove), (pieces() ^ kfrom ^ rfrom) | rto | kto, sideToMove))
+          && attackers_to(ksq, (piecesAll ^ kfrom ^ rfrom) | rto | kto, sideToMove))
           return true;
 
-      return   (PseudoAttacks[sideToMove][type_of(piece_on(rfrom))][rto] & square<KING>(~sideToMove))
-            && (attacks_bb(sideToMove, type_of(piece_on(rfrom)), rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & square<KING>(~sideToMove));
+      return   (PseudoAttacks[sideToMove][type_of(piece_on(rfrom))][rto] & ksqBB)
+            && (attacks_bb(sideToMove, type_of(piece_on(rfrom)), rto, (piecesAll ^ kfrom ^ rfrom) | rto | kto) & ksqBB);
   }
   }
 }


### PR DESCRIPTION
 ## Summary
  - Cache opponent king square and `pieces()` in `Position::gives_check`.

  ## Technical details
  - Store `ksq`, `ksqBB`, and `piecesAll` once and reuse them across direct/discovered/gated/diagonal check paths.
  - This reduces repeated board queries without altering check logic.

  ## Performance
  - bench (nodes/s vs baseline): chess 329489 → 334885 (+1.6%).
  - Baseline is `stockfish_base.exe` from the perf log; deltas are incremental on top of prior accepted optimizations.

  ## Tests
  - tests/protocol.sh
  - tests/perft.sh chess
  - tests/regression.sh chess capablanca xiangqi shogi