### PR TITLE
Cache MoveType in capture helpers

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -1445,13 +1445,15 @@ inline bool Position::is_chess960() const {
 
 inline bool Position::capture_or_promotion(Move m) const {
   assert(is_ok(m));
-  return type_of(m) == PROMOTION || type_of(m) == EN_PASSANT || (type_of(m) != CASTLING && !empty(to_sq(m)));
+  const MoveType mt = type_of(m);
+  return mt == PROMOTION || mt == EN_PASSANT || (mt != CASTLING && !empty(to_sq(m)));
 }
 
 inline bool Position::capture(Move m) const {
   assert(is_ok(m));
   // Castling is encoded as "king captures rook"
-  return (!empty(to_sq(m)) && type_of(m) != CASTLING && from_sq(m) != to_sq(m)) || type_of(m) == EN_PASSANT;
+  const MoveType mt = type_of(m);
+  return (!empty(to_sq(m)) && mt != CASTLING && from_sq(m) != to_sq(m)) || mt == EN_PASSANT;
 }
 
 inline Square Position::capture_square(Square to) const {


### PR DESCRIPTION
 ## Summary
  - Cache `MoveType` in `capture()` and `capture_or_promotion()` helpers.

  ## Technical details
  - Store `mt = type_of(m)` once per helper and use it for promotion/castling/en-passant checks.
  - This reduces repeated move-type decoding in tight helpers used across search/movegen.

  ## Performance
  - bench (nodes/s vs baseline): chess 328159 → 335729 (+2.3%).
  - Baseline is `stockfish_base.exe` from the perf log; deltas are incremental on top of prior accepted optimizations.

  ## Tests
  - tests/protocol.sh
  - tests/perft.sh chess
  - tests/regression.sh chess capablanca xiangqi shogi