### PR TITLE
Cache pieces(c) in fastAttacks attackers_to

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -928,11 +928,12 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied, Color c, Bitboard j
   // Use a faster version for variants with moderate rule variations
   if (var->fastAttacks)
   {
-      return  (pawn_attacks_bb(~c, s)          & pieces(c, PAWN))
-            | (attacks_bb<KNIGHT>(s)           & pieces(c, KNIGHT, ARCHBISHOP, CHANCELLOR))
-            | (attacks_bb<  ROOK>(s, occupied) & pieces(c, ROOK, QUEEN, CHANCELLOR))
-            | (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN, ARCHBISHOP))
-            | (attacks_bb<KING>(s)             & pieces(c, KING, COMMONER));
+      const Bitboard piecesC = pieces(c);
+      return  (pawn_attacks_bb(~c, s)          & (piecesC & pieces(PAWN)))
+            | (attacks_bb<KNIGHT>(s)           & (piecesC & (pieces(KNIGHT) | pieces(ARCHBISHOP) | pieces(CHANCELLOR))))
+            | (attacks_bb<  ROOK>(s, occupied) & (piecesC & (pieces(ROOK) | pieces(QUEEN) | pieces(CHANCELLOR))))
+            | (attacks_bb<BISHOP>(s, occupied) & (piecesC & (pieces(BISHOP) | pieces(QUEEN) | pieces(ARCHBISHOP))))
+            | (attacks_bb<KING>(s)             & (piecesC & (pieces(KING) | pieces(COMMONER))));
   }
 
   // Use a faster version for selected fairy pieces


### PR DESCRIPTION
## Summary
  - Cache `pieces(c)` once in the fastAttacks branch of `attackers_to()`.

  ## Technical details
  - Store `piecesC = pieces(c)` and intersect with per-type bitboards (e.g., `piecesC & pieces(PAWN)`), avoiding repeated `pieces(c, ...)` calls.
  - Keeps the same fastAttacks logic while reducing container access and bitboard assembly overhead.

  ## Performance
  - bench (nodes/s vs baseline): chess 325039 → 334294 (+2.9%).
  - Baseline is `stockfish_base.exe` from the perf log; deltas are incremental on top of prior accepted optimizations.

  ## Tests
  - tests/protocol.sh
  - tests/perft.sh chess
  - tests/regression.sh chess capablanca xiangqi shogi