### PR TITLE
Cache pawnBoard/occupied in pawn movegen

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -147,9 +147,11 @@ namespace {
     const Bitboard doubleStepRegion = pos.double_step_region(Us);
     const Bitboard tripleStepRegion = pos.triple_step_region(Us);
 
+    const Bitboard occupied  = pos.pieces();
+    const Bitboard pawnBoard = pos.board_bb(Us, PAWN);
     const Bitboard pawns      = pos.pieces(Us, PAWN);
-    const Bitboard movable    = pos.board_bb(Us, PAWN) & ~pos.pieces();
-    const Bitboard capturable = pos.board_bb(Us, PAWN) &  pos.pieces(Them);
+    const Bitboard movable    = pawnBoard & ~occupied;
+    const Bitboard capturable = pawnBoard &  pos.pieces(Them);
 
     target = Type == EVASIONS ? target : AllSquares;
 
@@ -238,11 +240,11 @@ namespace {
                 PieceType pt = pop_msb(ps);
                 if (pos.promotion_limit(pt) && pos.promotion_limit(pt) <= pos.count(Us, pt))
                     continue;
-                Bitboard b = ((pos.attacks_from(Us, pt, from) & ~pos.pieces()) | from) & target;
+                Bitboard b = ((pos.attacks_from(Us, pt, from) & ~occupied) | from) & target;
                 while (b)
                 {
                     Square to = pop_lsb(b);
-                    if (!(attacks_bb(Us, pt, to, pos.pieces() ^ from) & pos.pieces(Them)))
+                    if (!(attacks_bb(Us, pt, to, occupied ^ from) & pos.pieces(Them)))
                         *moveList++ = make<PROMOTION>(from, to, pt);
                 }
             }
@@ -264,7 +266,7 @@ namespace {
             moveList = make_move_and_gating<NORMAL>(pos, moveList, Us, to - UpLeft, to);
         }
 
-        for (Bitboard epSquares = pos.ep_squares() & ~pos.pieces(); epSquares; )
+        for (Bitboard epSquares = pos.ep_squares() & ~occupied; epSquares; )
         {
             Square epSquare = pop_lsb(epSquares);
 


### PR DESCRIPTION
## Summary
  - Cache `occupied` and pawn board region in `generate_pawn_moves()`.

  ## Technical details
  - Compute `occupied = pos.pieces()` and `pawnBoard = pos.board_bb(Us, PAWN)` once and reuse for movable/capturable squares, en-passant filtering, and promotion checks.
  - Reduces repeated `pos.pieces()` / `pos.board_bb()` calls in pawn move generation.

  ## Performance
  - bench (nodes/s vs baseline, avg of 3 runs): chess 329856 → 335523 (+1.7%).
  - Baseline is `stockfish_base.exe` from the perf log; deltas are incremental on top of prior accepted optimizations.

  ## Tests
  - tests/protocol.sh
  - tests/perft.sh chess
  - tests/regression.sh chess capablanca xiangqi shogi