### PR TITLE
Stabilize spell chess potion search

### DIFF
--- a/perf_optimizations_log.txt
+++ b/perf_optimizations_log.txt
@@ -1,5 +1,8 @@
 # Spell-chess perf ideas log
 Date: 2026-01-17
+Build requirement: Spell Chess is available only in an `all=yes` build, which
+uses the expanded 16384-move list. For example: `cd src && make -j build
+ARCH=x86-64-modern all=yes`.
 Baseline: spell/nnue-potions (post-v2 merge), bench uses UCI_Variant=spell-chess,
 Use NNUE=true, EvalFile=spell-chess_run1test_e4_l05.nnue.
 Perft: startpos depth1=1814, depth2=3007820, branching=1658.11.

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -578,6 +578,12 @@ namespace {
     {
         Bitboard kingAttacks = pos.attacks_from(Us, royal, ksq) & pos.pieces();
         Bitboard kingMoves   = pos.moves_from  (Us, royal, ksq) & ~pos.pieces();
+        if (pos.potions_enabled() && pos.allow_self_check())
+        {
+            Bitboard adjacent = PseudoAttacks[WHITE][KING][ksq];
+            kingAttacks = adjacent & pos.pieces();
+            kingMoves = adjacent & ~pos.pieces();
+        }
         Bitboard kingCaptureMask = Type == EVASIONS ? ~pos.pieces(Us) : captureTarget;
         if (Type == EVASIONS && pos.self_capture())
             kingCaptureMask |= pos.pieces(Us) & ~pos.pieces(Us, royal);
@@ -1037,7 +1043,13 @@ template ExtMove* generate<NON_EVASIONS>(const Position&, ExtMove*);
 template<>
 ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 
-  if (pos.is_immediate_game_end())
+  if (pos.potions_enabled())
+  {
+      PieceType royal = pos.royal_piece_type();
+      if (!pos.count(WHITE, royal) || !pos.count(BLACK, royal))
+          return moveList;
+  }
+  else if (pos.is_immediate_game_end())
       return moveList;
 
   ExtMove* cur = moveList;
@@ -1050,6 +1062,38 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
           *cur = (--end)->move;
       else
           ++cur;
+
+  // The Spell Chess royal is capturable.  Keep its ordinary adjacent moves in
+  // the legal list even when the generic king path classifies the position as
+  // checked; that path is for orthodox evasion rules.
+  if (pos.potions_enabled())
+  {
+      Color us = pos.side_to_move();
+      PieceType royal = pos.royal_piece_type();
+      if (pos.count(us, royal))
+      {
+          Square from = pos.square(us, royal);
+          if (!(pos.freeze_squares(us) & from))
+              for (Bitboard b = PseudoAttacks[WHITE][KING][from]; b; )
+              {
+                  Square to = pop_lsb(b);
+                  if (pos.pieces(us) & to)
+                      continue;
+                  if ((pos.jump_squares(us) & to) && !(pos.pieces(~us) & to))
+                      continue;
+                  Move m = make<NORMAL>(from, to);
+                  bool exists = false;
+                  for (ExtMove* scan = moveList; scan != end; ++scan)
+                      if (scan->move == m)
+                      {
+                          exists = true;
+                          break;
+                      }
+                  if (!exists)
+                      *end++ = m;
+              }
+      }
+  }
 
   // Add potion moves, filtering by legality and avoiding duplicates.
   if (pos.potions_enabled())

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -679,7 +679,7 @@ namespace {
                         continue;
 
                     MoveType mt = type_of(base);
-                    if (mt != NORMAL && mt != CASTLING)
+                    if (mt != NORMAL && mt != CASTLING && mt != EN_PASSANT)
                         continue;
 
                     if (newBlockZone & from_sq(base))
@@ -691,7 +691,9 @@ namespace {
 
                     Move gatingMove = mt == NORMAL
                                       ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
-                                      : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
+                                      : mt == CASTLING
+                                          ? make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate)
+                                          : make_gating<EN_PASSANT>(from_sq(base), to_sq(base), potionPiece, gate);
 
                     write->move = gatingMove;
                     write->value = gateScore;
@@ -712,7 +714,7 @@ namespace {
                     continue;
 
                 MoveType mt = type_of(base);
-                if (mt != NORMAL && mt != CASTLING)
+                if (mt != NORMAL && mt != CASTLING && mt != EN_PASSANT)
                     continue;
 
                 if (to_sq(base) == gate)
@@ -720,7 +722,9 @@ namespace {
 
                 Move gatingMove = mt == NORMAL
                                   ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
-                                  : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
+                                  : mt == CASTLING
+                                      ? make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate)
+                                      : make_gating<EN_PASSANT>(from_sq(base), to_sq(base), potionPiece, gate);
 
                 write->move = gatingMove;
                 write->value = gateScore;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -122,7 +122,11 @@ bool MovePicker::is_potion_move(Move m) const {
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh, const LowPlyHistory* lp,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, const Move* killers, int pl)
-           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
+           : pos(p),
+#ifdef ALLVARS
+             moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()),
+#endif
+             mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
              ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, quietStart(moves), quietEnd(moves), depth(d), ply(pl) {
 
   assert(d > 0);
@@ -135,7 +139,11 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), quietStart(moves), quietEnd(moves), recaptureSquare(rs), depth(d) {
+           : pos(p),
+#ifdef ALLVARS
+             moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()),
+#endif
+             mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), quietStart(moves), quietEnd(moves), recaptureSquare(rs), depth(d) {
 
   assert(d <= 0);
 
@@ -149,7 +157,11 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory* dh, const CapturePieceToHistory* cph)
-           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
+           : pos(p),
+#ifdef ALLVARS
+             moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()),
+#endif
+             gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
 
   assert(!pos.checkers() || pos.allow_self_check());
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -122,7 +122,7 @@ bool MovePicker::is_potion_move(Move m) const {
 /// MovePicker constructor for the main search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh, const LowPlyHistory* lp,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Move cm, const Move* killers, int pl)
-           : pos(p), mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
+           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), mainHistory(mh), gateHistory(dh), lowPlyHistory(lp), captureHistory(cph), continuationHistory(ch),
              ttMove(ttm), refutations{{killers[0], 0}, {killers[1], 0}, {cm, 0}}, quietStart(moves), quietEnd(moves), depth(d), ply(pl) {
 
   assert(d > 0);
@@ -135,7 +135,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for quiescence search
 MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHistory* mh, const GateHistory* dh,
                        const CapturePieceToHistory* cph, const PieceToHistory** ch, Square rs)
-           : pos(p), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), quietStart(moves), quietEnd(moves), recaptureSquare(rs), depth(d) {
+           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), mainHistory(mh), gateHistory(dh), captureHistory(cph), continuationHistory(ch), ttMove(ttm), quietStart(moves), quietEnd(moves), recaptureSquare(rs), depth(d) {
 
   assert(d <= 0);
 
@@ -149,7 +149,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, Depth d, const ButterflyHist
 /// MovePicker constructor for ProbCut: we generate captures with SEE greater
 /// than or equal to the given threshold.
 MovePicker::MovePicker(const Position& p, Move ttm, Value th, const GateHistory* dh, const CapturePieceToHistory* cph)
-           : pos(p), gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
+           : pos(p), moveStorage(new ExtMove[MAX_MOVES]), moves(moveStorage.get()), gateHistory(dh), captureHistory(cph), ttMove(ttm), quietStart(moves), quietEnd(moves), threshold(th) {
 
   assert(!pos.checkers() || pos.allow_self_check());
 

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <limits>
+#include <memory>
 #include <type_traits>
 
 #include "movegen.h"
@@ -151,6 +152,8 @@ private:
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
+  std::unique_ptr<ExtMove[]> moveStorage;
+  ExtMove* moves;
   const ButterflyHistory* mainHistory;
   const GateHistory* gateHistory;
   const LowPlyHistory* lowPlyHistory;
@@ -163,7 +166,6 @@ private:
   Value threshold;
   Depth depth;
   int ply;
-  ExtMove moves[MAX_MOVES];
 };
 
 } // namespace Stockfish

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -21,7 +21,9 @@
 
 #include <array>
 #include <limits>
+#ifdef ALLVARS
 #include <memory>
+#endif
 #include <type_traits>
 
 #include "movegen.h"
@@ -152,8 +154,12 @@ private:
   ExtMove* end() { return endMoves; }
 
   const Position& pos;
+#ifdef ALLVARS
   std::unique_ptr<ExtMove[]> moveStorage;
   ExtMove* moves;
+#else
+  ExtMove moves[MAX_MOVES];
+#endif
   const ButterflyHistory* mainHistory;
   const GateHistory* gateHistory;
   const LowPlyHistory* lowPlyHistory;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1751,6 +1751,12 @@ bool Position::pseudo_legal(const Move m) const {
           return false;
   }
 
+  // Spell Chess uses a capturable royal.  Its ordinary adjacent moves must
+  // not be filtered through the orthodox king-attack path below: in
+  // particular, it may capture an attacker after a jump potion opened a line.
+  if (potions_enabled() && allow_self_check() && type_of(pc) == royal)
+      return PseudoAttacks[WHITE][KING][from] & to;
+
   Piece captured = NO_PIECE;
   if (capture(m))
   {

--- a/src/position.h
+++ b/src/position.h
@@ -957,9 +957,7 @@ inline Bitboard Position::freeze_zone_from_square(Square s) const {
 }
 
 inline Bitboard Position::freeze_block_zone_from_square(Square s) const {
-  Bitboard zone = square_bb(s);
-  zone |= shift<NORTH>(zone) | shift<SOUTH>(zone) | shift<EAST>(zone) | shift<WEST>(zone);
-  return zone & board_bb();
+  return freeze_zone_from_square(s);
 }
 
 inline bool Position::gating() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1011,6 +1011,9 @@ namespace {
     // Step 8. Null move search with verification search (~40 Elo)
     if (   !PvNode
         && !ss->inCheck
+        // Extinction variants can allow the royal piece to remain attacked, so
+        // ss->inCheck may be false while a null move would still be invalid.
+        && !pos.checkers()
         && (ss-1)->currentMove != MOVE_NULL
         && (ss-1)->statScore < 23767
         &&  eval >= beta

--- a/src/types.h
+++ b/src/types.h
@@ -231,7 +231,8 @@ constexpr int SQUARE_BITS = 6;
 #define USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 
 #ifdef ALLVARS
-constexpr int MAX_MOVES = 8192;
+// Spell Chess can combine each ordinary move with many potion targets.
+constexpr int MAX_MOVES = 16384;
 #ifdef USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 constexpr int MAX_PLY = 246;
 #else
@@ -239,8 +240,7 @@ constexpr int MAX_PLY = 60;
 #endif
 /// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #else
-// Potion gating combines each ordinary move with many spell targets.
-constexpr int MAX_MOVES = 16384;
+constexpr int MAX_MOVES = 4096;
 constexpr int MAX_PLY = 246;
 #endif
 /// endif ALLVARS

--- a/src/types.h
+++ b/src/types.h
@@ -239,7 +239,8 @@ constexpr int MAX_PLY = 60;
 #endif
 /// endif USE_HEAP_INSTEAD_OF_STACK_FOR_MOVE_LIST
 #else
-constexpr int MAX_MOVES = 4096;
+// Potion gating combines each ordinary move with many spell targets.
+constexpr int MAX_MOVES = 16384;
 constexpr int MAX_PLY = 246;
 #endif
 /// endif ALLVARS

--- a/src/types.h
+++ b/src/types.h
@@ -818,7 +818,8 @@ inline Square gating_square(Move m) {
 }
 
 inline bool is_gating(Move m) {
-  return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING);
+  return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING
+                            || type_of(m) == EN_PASSANT);
 }
 
 inline bool is_pass(Move m) {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -80,6 +80,7 @@ namespace {
         v->doubleStepRegion[BLACK] = AllSquares;
         return v;
     }
+#ifdef ALLVARS // Spell Chess requires the expanded all-variants move list.
     Variant* spell_chess_variant() {
         Variant* v = chess_variant()->init();
         v->variantTemplate = "spell-chess";
@@ -103,6 +104,7 @@ namespace {
         v->startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[JJFFFFFjjfffff] w KQkq - 0 1";
         return v;
     }
+#endif
     // Berolina Chess
     // https://www.chessvariants.com/dpieces.dir/berlin.html
     Variant* berolina_variant() {
@@ -1875,7 +1877,9 @@ void VariantMap::init() {
     add("nocastle", nocastle_variant());
     add("armageddon", armageddon_variant());
     add("torpedo", torpedo_variant());
+#ifdef ALLVARS
     add("spell-chess", spell_chess_variant());
+#endif
     add("berolina", berolina_variant());
     add("pawnsideways", pawnsideways_variant());
     add("pawnback", pawnback_variant());


### PR DESCRIPTION
## Summary

Stabilizes `spell-chess` potion search under timed NNUE search and makes its expanded move capacity an explicit `all=yes` requirement.

## Why

Timed paired games exposed three independent failures:

1. Potion gating can produce far more than the upstream 4,096 moves. A stress position produces 11,046 legal moves. The former 8,192-move `all=yes` buffer corrupts the heap.
2. Null-move pruning could run while an extinction/capturable royal was attacked, violating `do_null_move()`'s quiet-position invariant.
3. Capturable-royal positions were still partially routed through orthodox check/evasion generation. This could reject a legal royal capture after a Jump potion opened a line, or report no move in a live position.

## Changes

- Keep the normal build at its upstream 4,096-move capacity and stack-backed `MovePicker`; ordinary variants do not pay for Spell Chess.
- Make `all=yes` use 16,384 moves and heap-backed `MovePicker` storage. A 16,384-element `ExtMove` array is 128 KiB per active search frame, so the heap storage remains necessary.
- Compile and register `spell-chess` only with `ALLVARS`; the normal UCI variant list excludes it. The spell performance log documents the required build command.
- Suppress null-move pruning when `checkers()` is non-empty.
- Keep capturable Spell Chess royal moves out of orthodox immediate-end/evasion filtering while preserving adjacency, occupancy, and freeze constraints.
- Treat Freeze as the full 3x3 zone for same-turn movement. This matches chess.com observations: a frozen piece cannot move, but a potion target does not block the accompanying piece's path or destination.

## Validation

- Built both normal and `all=yes` configurations.
- Normal build excludes `spell-chess`; `all=yes` advertises it.
- `all=yes` passes the existing spell reference perft (5 nodes) and the 11,046-move perft/search stress case without corruption.
- Completed a 96-game, 150 ms/move paired tournament with three Spell Chess NNUE files plus a no-NNUE FSX referee: 95 king captures and one referee-confirmed stalemate; no crashes or legal-move disagreements.

The chess.com observations used here are summarized above because the local reference notes are not part of this repository.

## Known follow-up

The branch still does not generate a castle from check when the same-turn Freeze potion neutralizes the checking rook. This is a chess.com-observed legal move (`f@e8,e1g1` in `4r1k1/8/8/8/8/8/8/4K2R[F] w K - - 0 1`). It needs a dedicated castling/evasion construction rather than broadening ordinary castling legality, so it is deliberately not included in this PR.
