### PR TITLE
Add frozen Atomic OpenBench baseline harness

### DIFF
--- a/docs/openbench-atomic-baseline.md
+++ b/docs/openbench-atomic-baseline.md
@@ -24,7 +24,10 @@ builds and Linux builds retain their upstream flags.
 OpenBench authenticates the assigned network before invoking Make. The shim
 copies that file to Fairy-Stockfish's canonical embedded name
 `atomic_run3b_e202_l05.nnue` and calls the private optimized `all` target
-directly. It intentionally does not call `build nnue=yes`, whose `net`
+directly. Before compiling it runs `objclean`, because neither the embedded
+network contents nor Make flags are object prerequisites in this historical
+Makefile; this makes reused checkouts safe from stale networks or non-harness
+objects. It intentionally does not call `build nnue=yes`, whose `net`
 prerequisite would reject the Atomic filename. The harness macro changes
 Fairy's compiled EvalFile default to that Atomic-prefixed canonical name; this
 is required by Fairy's variant-to-network safety check and leaves non-harness

--- a/docs/openbench-atomic-baseline.md
+++ b/docs/openbench-atomic-baseline.md
@@ -21,6 +21,10 @@ baseline, plus `-save-temps -Wl,--no-insert-timestamp` for deterministic PE
 linking. These additions are scoped to the Windows OpenBench target; ordinary
 builds and Linux builds retain their upstream flags.
 
+The historical `net` target filters explicitly for the orthodox
+`nn-<12 lowercase hexadecimal digits>.nnue` pattern. The additional Atomic
+default branch therefore cannot alter normal NNUE download discovery.
+
 OpenBench authenticates the assigned network before invoking Make. The shim
 copies that file to Fairy-Stockfish's canonical embedded name
 `atomic_run3b_e202_l05.nnue` and calls the private optimized `all` target

--- a/docs/openbench-atomic-baseline.md
+++ b/docs/openbench-atomic-baseline.md
@@ -1,0 +1,52 @@
+# Frozen Fairy-Stockfish Atomic baseline on OpenBench
+
+This branch is a non-playing harness pinned to upstream Fairy-Stockfish commit
+`fb78cb561aa01708338e35b3dc3b65a42149a3c4`. It exists only to make the
+historical Atomic baseline reproducible on public OpenBench workers; the oracle
+checkout remains untouched.
+
+The worker contract from `src/` is:
+
+```text
+make -j EXE=<output> CXX=<compiler> EVALFILE=<absolute-network-path>
+```
+
+When `EVALFILE` is present, the default goal builds `x86-64-bmi2` with
+`all=no`, `largeboards=no`, and `nnue=yes`. It uses MinGW on Windows and GCC on
+Linux, while preserving the worker's `EXE` and `CXX`. A normal developer
+`make` without `EVALFILE` keeps Fairy-Stockfish's original `help` default.
+Fairy's historical native-MinGW path omits LTO, so the shim supplies the exact
+`-flto -flto-partition=one` compile/link flags used by the frozen optimized
+baseline, plus `-save-temps -Wl,--no-insert-timestamp` for deterministic PE
+linking. These additions are scoped to the Windows OpenBench target; ordinary
+builds and Linux builds retain their upstream flags.
+
+OpenBench authenticates the assigned network before invoking Make. The shim
+copies that file to Fairy-Stockfish's canonical embedded name
+`atomic_run3b_e202_l05.nnue` and calls the private optimized `all` target
+directly. It intentionally does not call `build nnue=yes`, whose `net`
+prerequisite would reject the Atomic filename. The harness macro changes
+Fairy's compiled EvalFile default to that Atomic-prefixed canonical name; this
+is required by Fairy's variant-to-network safety check and leaves non-harness
+builds unchanged.
+
+The frozen Atomic network is `atomic_run3b_e202_l05.nnue`, SHA-256
+`99DC67EABF26A64FAEECA3A88B4C38597A840B8D4A874B9F2CF658C6F92A04A6`.
+The public binary contains that network and does not depend on the worker's
+temporary download path.
+
+`OPENBENCH_ATOMIC_BASELINE` changes only missing defaults in the benchmark
+command. Bare `bench` is therefore equivalent to:
+
+```text
+bench atomic 16 1 13 default depth NNUE
+```
+
+Its deterministic signature with the frozen network is:
+
+```text
+Nodes searched  : 97362
+```
+
+Explicit benchmark arguments still take precedence. Search, evaluation,
+variant rules, protocols, and all game-time options are unchanged.

--- a/src/Makefile
+++ b/src/Makefile
@@ -980,3 +980,50 @@ icc-profile-use:
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
 
 -include .depend
+
+### ==========================================================================
+### Section 6. Frozen Atomic OpenBench harness
+### ==========================================================================
+# OpenBench builds public engines from src/ with a bare
+#
+#   make -j EXE=<output> CXX=<compiler> EVALFILE=<network>
+#
+# Do not use the regular `build nnue=yes` target here: its `net` prerequisite
+# validates the orthodox network filename hash. Instead copy OpenBench's
+# authenticated Atomic network to Fairy-Stockfish's canonical embedded name
+# and invoke the optimized private target directly.
+
+OPENBENCH_ATOMIC_NET = atomic_run3b_e202_l05.nnue
+
+ifeq ($(OS),Windows_NT)
+    OPENBENCH_ATOMIC_COMP = mingw
+    # Fairy's historical MinGW path enables O3 but only enables LTO when
+    # cross-compiling from Linux. Match the frozen native-Windows baseline's
+    # explicit O3+LTO and deterministic PE link flags.
+    OPENBENCH_ATOMIC_CXXFLAGS = -flto -flto-partition=one
+    OPENBENCH_ATOMIC_LDFLAGS = -flto -flto-partition=one -save-temps -Wl,--no-insert-timestamp
+else
+    OPENBENCH_ATOMIC_COMP = gcc
+    OPENBENCH_ATOMIC_CXXFLAGS =
+    OPENBENCH_ATOMIC_LDFLAGS =
+endif
+
+.PHONY: openbench-atomic-baseline
+openbench-atomic-baseline:
+ifndef EVALFILE
+	@echo "ERROR: the frozen Atomic baseline requires EVALFILE=<Legacy Atomic V1 network>." >&2
+	@exit 2
+else
+	@test -f "$(EVALFILE)" || { echo "ERROR: OpenBench EVALFILE does not exist: $(EVALFILE)" >&2; exit 2; }
+	@cp "$(EVALFILE)" "$(OPENBENCH_ATOMIC_NET).tmp"
+	@mv "$(OPENBENCH_ATOMIC_NET).tmp" "$(OPENBENCH_ATOMIC_NET)"
+	+$(MAKE) all EXE="$(EXE)" CXX="$(CXX)" \
+		ARCH=x86-64-bmi2 COMP=$(OPENBENCH_ATOMIC_COMP) \
+		all=no largeboards=no nnue=yes \
+		EXTRACXXFLAGS='$(EXTRACXXFLAGS) $(OPENBENCH_ATOMIC_CXXFLAGS) -DOPENBENCH_ATOMIC_BASELINE' \
+		EXTRALDFLAGS='$(EXTRALDFLAGS) $(OPENBENCH_ATOMIC_LDFLAGS)'
+endif
+
+ifneq ($(strip $(EVALFILE)),)
+.DEFAULT_GOAL := openbench-atomic-baseline
+endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -1017,6 +1017,7 @@ else
 	@test -f "$(EVALFILE)" || { echo "ERROR: OpenBench EVALFILE does not exist: $(EVALFILE)" >&2; exit 2; }
 	@cp "$(EVALFILE)" "$(OPENBENCH_ATOMIC_NET).tmp"
 	@mv "$(OPENBENCH_ATOMIC_NET).tmp" "$(OPENBENCH_ATOMIC_NET)"
+	+$(MAKE) objclean EXE="$(EXE)"
 	+$(MAKE) all EXE="$(EXE)" CXX="$(CXX)" \
 		ARCH=x86-64-bmi2 COMP=$(OPENBENCH_ATOMIC_COMP) \
 		all=no largeboards=no nnue=yes \

--- a/src/Makefile
+++ b/src/Makefile
@@ -822,7 +822,7 @@ clean: objclean profileclean
 
 # evaluation network (nnue)
 net:
-	$(eval nnuenet := $(shell grep EvalFileDefaultName evaluate.h | grep define | sed 's/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/'))
+	$(eval nnuenet := $(shell grep EvalFileDefaultName evaluate.h | sed -n 's/.*\(nn-[a-z0-9]\{12\}\.nnue\).*/\1/p' | head -n 1))
 	@echo "Default net: $(nnuenet)"
 	$(eval nnuedownloadurl1 := https://tests.stockfishchess.org/api/nn/$(nnuenet))
 	$(eval nnuedownloadurl2 := https://github.com/official-stockfish/networks/raw/master/$(nnuenet))

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -123,7 +123,13 @@ vector<string> setup_bench(const Position& current, istream& is) {
   else
   {
       is.seekg(args);
+#ifdef OPENBENCH_ATOMIC_BASELINE
+      // The frozen OpenBench harness must validate the same Atomic NNUE path
+      // used by its games. Explicit benchmark arguments remain unchanged.
+      varname = "atomic";
+#else
       varname = string(Options["UCI_Variant"]);
+#endif
   }
   const Variant* variant = variants.find(varname)->second;
 
@@ -133,7 +139,12 @@ vector<string> setup_bench(const Position& current, istream& is) {
   string limit     = (is >> token) ? token : "13";
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
-  string evalType  = (is >> token) ? token : "mixed";
+  string evalType  = (is >> token) ? token
+#ifdef OPENBENCH_ATOMIC_BASELINE
+                                   : "NNUE";
+#else
+                                   : "mixed";
+#endif
 
   go = limitType == "eval" ? "eval" : "go " + limitType + " " + limit;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -38,10 +38,16 @@ namespace Eval {
   extern bool useNNUE;
   extern std::string eval_file_loaded;
 
-  // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
-  // for the build process (profile-build and fishtest) to work. Do not change the
-  // name of the macro, as it is used in the Makefile.
+  // The normal default net name MUST follow the format
+  // nn-[SHA256 first 12 digits].nnue for profile-build and fishtest. The frozen
+  // OpenBench harness bypasses the downloader and embeds its authenticated
+  // variant net under an Atomic-prefixed name so NNUE variant selection accepts
+  // it. Do not change the macro name; the Makefile consumes it.
+  #ifdef OPENBENCH_ATOMIC_BASELINE
+  #define EvalFileDefaultName   "atomic_run3b_e202_l05.nnue"
+  #else
   #define EvalFileDefaultName   "nn-3475407dc199.nnue"
+  #endif
 
   namespace NNUE {
 

--- a/tests/test_openbench_atomic_baseline.py
+++ b/tests/test_openbench_atomic_baseline.py
@@ -92,6 +92,20 @@ class OpenBenchAtomicBaselineContractTests(unittest.TestCase):
             HARNESS,
         )
 
+    def test_normal_net_discovery_ignores_the_atomic_override(self):
+        assignment = re.search(
+            r"\$\(eval nnuenet := \$\(shell (?P<pipeline>[^\n]+)\)\)", MAKEFILE
+        )
+        self.assertIsNotNone(assignment)
+        pipeline = assignment.group("pipeline")
+        self.assertIn("grep EvalFileDefaultName evaluate.h", pipeline)
+        self.assertIn("sed -n", pipeline)
+        self.assertIn(r"nn-[a-z0-9]\{12\}\.nnue", pipeline)
+        self.assertIn("head -n 1", pipeline)
+
+        normal_names = re.findall(r"nn-[a-z0-9]{12}\.nnue", EVALUATE)
+        self.assertEqual(normal_names, ["nn-3475407dc199.nnue"])
+
     def test_harness_only_changes_missing_bench_defaults(self):
         self.assertIn(
             """#ifdef OPENBENCH_ATOMIC_BASELINE

--- a/tests/test_openbench_atomic_baseline.py
+++ b/tests/test_openbench_atomic_baseline.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = (ROOT / "src" / "Makefile").read_text(encoding="utf-8")
+BENCHMARK = (ROOT / "src" / "benchmark.cpp").read_text(encoding="utf-8")
+EVALUATE = (ROOT / "src" / "evaluate.h").read_text(encoding="utf-8")
+HARNESS = MAKEFILE.split("### Section 6. Frozen Atomic OpenBench harness", 1)[1]
+
+
+class OpenBenchAtomicBaselineContractTests(unittest.TestCase):
+
+    def test_evalfile_only_replaces_the_default_goal_for_openbench(self):
+        self.assertRegex(
+            HARNESS,
+            r"ifneq \(\$\(strip \$\(EVALFILE\)\),\)\s*"
+            r"\.DEFAULT_GOAL := openbench-atomic-baseline\s*endif\s*$",
+        )
+
+    def test_windows_and_linux_use_the_normative_compilers(self):
+        mapping = re.search(
+            r"ifeq \(\$\(OS\),Windows_NT\)\s*"
+            r"OPENBENCH_ATOMIC_COMP = (?P<windows>\S+).*?\s*else\s*"
+            r"OPENBENCH_ATOMIC_COMP = (?P<linux>\S+)",
+            HARNESS,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(mapping)
+        self.assertEqual(
+            mapping.groupdict(), {"windows": "mingw", "linux": "gcc"}
+        )
+
+    def test_native_windows_replays_the_frozen_lto_link_contract(self):
+        windows = re.search(
+            r"ifeq \(\$\(OS\),Windows_NT\)(?P<body>.*?)\s*else\s*"
+            r"OPENBENCH_ATOMIC_COMP = gcc",
+            HARNESS,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(windows)
+        body = windows.group("body")
+        self.assertIn(
+            "OPENBENCH_ATOMIC_CXXFLAGS = -flto -flto-partition=one", body
+        )
+        self.assertIn(
+            "OPENBENCH_ATOMIC_LDFLAGS = -flto -flto-partition=one "
+            "-save-temps -Wl,--no-insert-timestamp",
+            body,
+        )
+        self.assertIn(
+            "EXTRACXXFLAGS='$(EXTRACXXFLAGS) "
+            "$(OPENBENCH_ATOMIC_CXXFLAGS) -DOPENBENCH_ATOMIC_BASELINE'",
+            HARNESS,
+        )
+        self.assertIn(
+            "EXTRALDFLAGS='$(EXTRALDFLAGS) $(OPENBENCH_ATOMIC_LDFLAGS)'",
+            HARNESS,
+        )
+
+    def test_public_build_is_the_frozen_small_bmi2_configuration(self):
+        self.assertRegex(
+            HARNESS,
+            r"\+\$\(MAKE\) all EXE=\"\$\(EXE\)\" CXX=\"\$\(CXX\)\"\s*\\\s*"
+            r"ARCH=x86-64-bmi2 COMP=\$\(OPENBENCH_ATOMIC_COMP\)\s*\\\s*"
+            r"all=no largeboards=no nnue=yes",
+        )
+        self.assertIn("-DOPENBENCH_ATOMIC_BASELINE", HARNESS)
+
+    def test_authenticated_network_uses_fairys_canonical_embedded_name(self):
+        self.assertRegex(
+            EVALUATE,
+            r"#ifdef OPENBENCH_ATOMIC_BASELINE\s*"
+            r'#define EvalFileDefaultName\s+"atomic_run3b_e202_l05\.nnue"\s*'
+            r"#else\s*"
+            r'#define EvalFileDefaultName\s+"nn-3475407dc199\.nnue"\s*'
+            r"#endif",
+        )
+        canonical = "atomic_run3b_e202_l05.nnue"
+        self.assertIn(f"OPENBENCH_ATOMIC_NET = {canonical}", HARNESS)
+        self.assertIn('cp "$(EVALFILE)" "$(OPENBENCH_ATOMIC_NET).tmp"', HARNESS)
+        self.assertIn(
+            'mv "$(OPENBENCH_ATOMIC_NET).tmp" "$(OPENBENCH_ATOMIC_NET)"',
+            HARNESS,
+        )
+
+    def test_harness_only_changes_missing_bench_defaults(self):
+        self.assertIn(
+            """#ifdef OPENBENCH_ATOMIC_BASELINE
+      // The frozen OpenBench harness must validate the same Atomic NNUE path
+      // used by its games. Explicit benchmark arguments remain unchanged.
+      varname = "atomic";
+#else""",
+            BENCHMARK,
+        )
+        self.assertIn(
+            """#ifdef OPENBENCH_ATOMIC_BASELINE
+                                   : "NNUE";
+#else""",
+            BENCHMARK,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openbench_atomic_baseline.py
+++ b/tests/test_openbench_atomic_baseline.py
@@ -70,6 +70,11 @@ class OpenBenchAtomicBaselineContractTests(unittest.TestCase):
         )
         self.assertIn("-DOPENBENCH_ATOMIC_BASELINE", HARNESS)
 
+    def test_public_build_cleans_stale_objects_before_embedding_the_net(self):
+        clean = HARNESS.index('+$(MAKE) objclean EXE="$(EXE)"')
+        build = HARNESS.index('+$(MAKE) all EXE="$(EXE)" CXX="$(CXX)"')
+        self.assertLess(clean, build)
+
     def test_authenticated_network_uses_fairys_canonical_embedded_name(self):
         self.assertRegex(
             EVALUATE,


### PR DESCRIPTION
## What

Adds a conditional OpenBench build/bench harness to the frozen Fairy-Stockfish Atomic oracle. The base branch is exactly upstream `fb78cb561aa01708338e35b3dc3b65a42149a3c4`; no modern Fairy changes are included.

## Why

OpenBench needs a public, reproducible baseline that compiles with the same Windows/Linux BMI2 assumptions and the exact frozen Atomic NNUE as Atomic-Stockfish. The harness is active only for the bare OpenBench build contract; normal Fairy builds and explicit bench arguments remain unchanged.

## Validation

- Clean MinGW x86-64-bmi2 build with AVX2, BMI2/PEXT, POPCNT and LTO
- Link flags include `-flto -flto-partition=one -save-temps -Wl,--no-insert-timestamp -static`
- Exact embedded net SHA-256: `99dc67eabf26a64faeeca3a88b4c38597a840b8d4a874b9f2cf658c6f92a04a6`
- Bare bench twice: `97362`, `97362`
- Standalone copied executable works without external network
- Explicit `bench chess 16 1 1 default depth classical`: 47 positions, 2124 nodes
- Contract tests: 6/6 passed
- `git diff --check`: passed

Bench: 97362