### PR TITLE
Support potion-gated en-passant captures

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -673,7 +673,7 @@ namespace {
                         continue;
 
                     MoveType mt = type_of(base);
-                    if (mt != NORMAL && mt != CASTLING)
+                    if (mt != NORMAL && mt != CASTLING && mt != EN_PASSANT)
                         continue;
 
                     if (newBlockZone & from_sq(base))
@@ -685,7 +685,9 @@ namespace {
 
                     Move gatingMove = mt == NORMAL
                                       ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
-                                      : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
+                                      : mt == CASTLING
+                                          ? make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate)
+                                          : make_gating<EN_PASSANT>(from_sq(base), to_sq(base), potionPiece, gate);
 
                     write->move = gatingMove;
                     write->value = gateScore;
@@ -706,7 +708,7 @@ namespace {
                     continue;
 
                 MoveType mt = type_of(base);
-                if (mt != NORMAL && mt != CASTLING)
+                if (mt != NORMAL && mt != CASTLING && mt != EN_PASSANT)
                     continue;
 
                 if (to_sq(base) == gate)
@@ -714,7 +716,9 @@ namespace {
 
                 Move gatingMove = mt == NORMAL
                                   ? make_gating<NORMAL>(from_sq(base), to_sq(base), potionPiece, gate)
-                                  : make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate);
+                                  : mt == CASTLING
+                                      ? make_gating<CASTLING>(from_sq(base), to_sq(base), potionPiece, gate)
+                                      : make_gating<EN_PASSANT>(from_sq(base), to_sq(base), potionPiece, gate);
 
                 write->move = gatingMove;
                 write->value = gateScore;

--- a/src/types.h
+++ b/src/types.h
@@ -817,7 +817,8 @@ inline Square gating_square(Move m) {
 }
 
 inline bool is_gating(Move m) {
-  return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING);
+  return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING
+                            || type_of(m) == EN_PASSANT);
 }
 
 inline bool is_pass(Move m) {


### PR DESCRIPTION
## Summary
- Allow Freeze and Jump potions to gate en-passant captures.
- Preserve the existing potion behavior; this only expands the eligible base move type.

## Validation
- `git diff --check`
- Built with `ARCH=x86-64-bmi2 largeboards=yes all=yes`.