### PR TITLE
Freeze the KOTH authority reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.sh text eol=lf
+*.py text eol=lf
 *.cpp text eol=lf
 *.h text eol=lf
 *.bat text eol=crlf

--- a/.github/workflows/koth-authority.yml
+++ b/.github/workflows/koth-authority.yml
@@ -1,0 +1,59 @@
+name: KOTH authority reference
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/koth-authority.yml"
+      - "docs/koth/**"
+      - "tests/koth_reference_test.py"
+      - "tools/koth_reference.py"
+      - "tools/reference/requirements.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/koth-authority.yml"
+      - "docs/koth/**"
+      - "tests/koth_reference_test.py"
+      - "tools/koth_reference.py"
+      - "tools/reference/requirements.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  reference:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.0"
+          cache: "pip"
+          cache-dependency-path: "tools/reference/requirements.lock"
+
+      - name: Install hashed reference dependency
+        run: >-
+          python -m pip install --disable-pip-version-check --no-deps
+          --require-hashes -r tools/reference/requirements.lock
+
+      - name: Verify no network weights are tracked
+        shell: pwsh
+        run: |
+          $tracked = @(git ls-files -- '*.nnue')
+          if ($tracked.Count -ne 0) {
+            $tracked | Write-Error
+            throw 'Public authority CI must not contain NNUE weights.'
+          }
+
+      - name: Run authority fixtures
+        run: |
+          python --version
+          python -m pip --version
+          python tools/koth_reference.py identity
+          python -m unittest -v tests/koth_reference_test.py

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The complete versioned contract, including terminal ordering, draw handling,
 loaded-position policy, notation, and persistence requirements, is in
 [`docs/koth/RULE_PROFILE.md`](docs/koth/RULE_PROFILE.md).
 
+The certified-match clock boundary is a separate, deterministic contract in
+[`docs/koth/CLOCK_PROFILE.md`](docs/koth/CLOCK_PROFILE.md). It intentionally
+does not emulate network lag compensation from an online server.
+
 ## Legacy network
 
 The official legacy compatibility network is an external asset identified by
@@ -37,6 +41,10 @@ current compatibility status.
 The public engineering state and gate boundary are recorded in
 [`docs/koth/STATUS.md`](docs/koth/STATUS.md). Results from smoke tests, canaries,
 or short matches are not promoted to Elo, correctness, or release evidence.
+
+The independent executable rules reference is documented in
+[`docs/koth/REFERENCE.md`](docs/koth/REFERENCE.md). It is a comparator under
+test, not an engine implementation or a release referee.
 
 ## Build
 

--- a/docs/koth/CLOCK_PROFILE.md
+++ b/docs/koth/CLOCK_PROFILE.md
@@ -1,0 +1,103 @@
+# KOTH_CLOCK_V1
+
+Status: frozen engineering contract; referee certification is pending.
+
+`KOTH_CLOCK_V1` defines the deterministic clock boundary for certified local
+KOTH-Stockfish engine matches. It is deliberately narrower than an online
+chess server. It has no network-lag compensation, human input allowance, or
+implementation-dependent grace period.
+
+## Supported time-control form
+
+The certified lane accepts sudden-death time controls of the form
+`base_ms + increment_ms`, with non-negative signed 64-bit integer values.
+Moves-per-period, delay, hourglass, byoyomi, and node-based clocks are rejected
+by the certified referee profile. Fixed-node work remains a test mode, not a
+clocked game.
+
+Each side starts its first engine-controlled turn with exactly `base_ms`.
+Opening-book or setup moves are an authenticated root prefix: they consume no
+clock and receive no increment. The first timed position, complete opening
+prefix, side to move, and both initial clocks are persisted before `go`.
+
+## Timing boundary
+
+The referee uses one process-wide monotonic clock with nanosecond readings.
+Wall time, timezone changes, and system-clock adjustment are irrelevant.
+
+For each proposal:
+
+1. `go_sent_ns` is sampled immediately after the complete newline-terminated
+   UCI `go` command has been written and flushed to the engine pipe.
+2. `proposal_received_ns` is sampled when the referee has received the final
+   byte of a complete newline-terminated `bestmove` line.
+3. `elapsed_ns = max(0, proposal_received_ns - go_sent_ns)`.
+4. `elapsed_ms = elapsed_ns / 1_000_000`, using integer truncation toward zero.
+5. `remaining_before_increment_ms = pre_clock_ms - elapsed_ms`, using checked
+   signed 64-bit arithmetic.
+
+The proposal is out of time when
+`remaining_before_increment_ms <= 0`. Equality is therefore a timeout. The
+profile has `lag_allowance_ms = 0` and `expiry_margin_ms = 0`.
+
+If the proposal is timely and legal, the move is committed once and then
+`increment_ms` is added with checked arithmetic. Increment is never granted to
+a timed-out, malformed, illegal, missing, or rejected proposal.
+
+## Transaction order
+
+The live referee must use this order without make/undo/make persistence:
+
+1. capture the pre-position, legal-move digest, clocks, and identities;
+2. send and flush `go`, then sample `go_sent_ns`;
+3. receive a complete proposal and sample `proposal_received_ns`;
+4. compute the clock decision;
+5. if timed out, persist a rejected-proposal receipt and end the game without
+   changing board state, UCI history, SAN, PGN moves, or repetition history;
+6. otherwise validate the proposal against the pre-position legal moves;
+7. compute SAN from the pre-position;
+8. commit the accepted move exactly once;
+9. add increment, compute terminal status, and persist the accepted record;
+10. either terminate or send the updated position to the engines.
+
+A timely hill move can win only after step 8. A late hill proposal loses on
+time at step 5 and never becomes a physical or recorded board transition.
+
+For a valid KOTH trajectory, the opponent retains winning potential while its
+king exists. Orthodox insufficient-material logic must not convert a KOTH
+timeout into a draw.
+
+## Failure and overflow policy
+
+- A monotonic-clock regression is `KCLOCK_E_MONOTONIC` and aborts the game.
+- Arithmetic overflow is `KCLOCK_E_RANGE` and aborts the game.
+- Unsupported time-control syntax is `KCLOCK_E_UNSUPPORTED` and rejects game
+  creation.
+- A partial or unterminated `bestmove` line is not a received proposal.
+- Engine crash, protocol EOF, malformed move, and illegal move are distinct
+  forfeits and are never rewritten as timeouts.
+- Timeout, crash, and protocol-forfeit records preserve the unchanged
+  pre-position and do not contain a committed `post_fen`.
+
+Canonical diagnostics contain stable codes and numeric fields, never localized
+OS text. Raw process transcripts are retained separately.
+
+## Required receipt fields
+
+Every proposal receipt must include at least:
+
+- `clock_profile = KOTH_CLOCK_V1`;
+- `pre_clock_ms`, `go_sent_ns`, `proposal_received_ns`, `elapsed_ns`, and
+  `elapsed_ms`;
+- `lag_allowance_ms = 0`, `expiry_margin_ms = 0`, and `increment_ms`;
+- the clock decision and stable reason code;
+- whether the proposal was accepted;
+- pre-position identity and, only for an accepted move, post-position identity;
+- engine, referee, rule-profile, and time-control identities.
+
+## Certification boundary
+
+This contract is not a clock certificate. Certification requires injected
+boundary tests below, at, and above expiry; real process-level tests; timeout
+state immutability; increment tests; book-prefix tests; crash/protocol tests;
+and independent recomputation from the recorded monotonic timestamps.

--- a/docs/koth/REFERENCE.md
+++ b/docs/koth/REFERENCE.md
@@ -1,0 +1,60 @@
+# Independent executable rules reference
+
+Status: implementation candidate; differential certification is pending.
+
+The project reference is `tools/koth_reference.py`. It uses standard physical
+move legality from `chess==1.11.2` and implements the frozen
+`KOTH_LICHESS_V1` trajectory, terminal-predicate, precedence, notation, and
+loaded-state policies in project-owned code.
+
+It is intentionally independent from the engine KOTH modules and from the
+tournament referee. It does not evaluate positions, search moves, load NNUE
+weights, manage processes, or adjudicate clocks.
+
+## Pinned dependency
+
+| Field | Identity |
+| --- | --- |
+| Package | `chess==1.11.2` |
+| Upstream source revision | `9c24454dcea4f8a30259d811a2f10b26e911deb4` |
+| Source archive | `chess-1.11.2.tar.gz` |
+| Source archive SHA-256 | `A8B43E5678FDB3000695BDAA573117AD683761E5CA38E591C4826EBA6D25BB39` |
+| License | GPL-3.0+ |
+
+The exact runtime interpreter, script bytes, installed package inventory, and
+their hashes belong in each execution receipt. A package version string alone
+is not an executable identity.
+
+## Input contract
+
+The CLI accepts one UTF-8 JSON object on standard input:
+
+```json
+{
+  "schema": "koth-reference-input-v1",
+  "rule_profile": "KOTH_LICHESS_V1",
+  "root_fen": "7k/8/8/8/8/2K5/8/8 w - - 0 1",
+  "moves": ["c3d4"]
+}
+```
+
+The root must be a canonical six-field standard-chess FEN. A physically
+invalid root, an already-terminal root, or either king already occupying a
+goal is rejected. Every UCI move token must be legal in sequence, and any
+token after the first terminal transition is rejected.
+
+Successful output includes each physical transition, SAN, post-FEN, sorted
+physical legal-move digest, all terminal predicates, primary reason, winner,
+and public result. Physical legal moves after a hill transition may exist; the
+game-legal continuation set is still empty.
+
+## Usage
+
+```sh
+python tools/koth_reference.py identity
+python tools/koth_reference.py replay < input.json
+python -m unittest tests/koth_reference_test.py
+```
+
+The reference must disagree loudly. It is not permitted to normalize a WLD,
+SAN, terminal-ply, predicate, or loaded-state mismatch into agreement.

--- a/docs/koth/RULE_PROFILE.md
+++ b/docs/koth/RULE_PROFILE.md
@@ -51,6 +51,10 @@ Clock adjudication precedes board progress: a move classified as out of time
 after clock and lag handling is a time loss, and its board transition is not
 committed as the game result.
 
+Certified local matches use the exact `KOTH_CLOCK_V1` profile in
+[`CLOCK_PROFILE.md`](CLOCK_PROFILE.md). Online-server lag compensation is
+evidence about Lichess operation, not an implicit input to local adjudication.
+
 ## Loaded positions
 
 FEN does not encode which player made the preceding move or authenticate a

--- a/docs/koth/STATUS.md
+++ b/docs/koth/STATUS.md
@@ -21,7 +21,8 @@ strength claim exists.
 | Gate | State | Meaning |
 | --- | --- | --- |
 | Discovery | Passed for engineering | Primary rule and source identities are frozen. |
-| Source/build | In progress | Reproducible project builds and deterministic digests are not yet certified. |
+| Authority freeze | In progress | The independent reference and deterministic clock profile are implemented but not yet certified. |
+| Source/build | Not started | Reproducible project builds and deterministic digests are not yet certified. |
 | Referee | Open | The unmodified tournament referee has known result and notation conflicts. |
 | Network loader | Failing diagnostic | Alias routing and full-byte authentication require engineering. |
 | CI/artifacts | Open | No project artifact is currently a release candidate. |

--- a/tests/koth_reference_test.py
+++ b/tests/koth_reference_test.py
@@ -1,0 +1,171 @@
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+import chess
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "koth_reference", ROOT / "tools" / "koth_reference.py"
+)
+assert SPEC and SPEC.loader
+REFERENCE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = REFERENCE
+SPEC.loader.exec_module(REFERENCE)
+
+
+def request(root_fen, *moves):
+    return {
+        "schema": "koth-reference-input-v1",
+        "rule_profile": "KOTH_LICHESS_V1",
+        "root_fen": root_fen,
+        "moves": list(moves),
+    }
+
+
+class KothReferenceTest(unittest.TestCase):
+    def test_every_goal_and_color(self):
+        cases = (
+            ("7k/8/8/8/8/2K5/8/8 w - - 0 1", "c3d4", "white"),
+            ("7k/8/8/8/8/3K4/8/8 w - - 0 1", "d3e4", "white"),
+            ("7k/8/8/8/2K5/8/8/8 w - - 0 1", "c4d5", "white"),
+            ("7k/8/8/8/5K2/8/8/8 w - - 0 1", "f4e5", "white"),
+            ("8/8/2k5/8/8/8/8/K7 b - - 0 1", "c6d5", "black"),
+            ("8/8/3k4/8/8/8/8/K7 b - - 0 1", "d6e5", "black"),
+            ("8/8/8/2k5/8/8/8/K7 b - - 0 1", "c5d4", "black"),
+            ("8/8/8/5k2/8/8/8/K7 b - - 0 1", "f5e4", "black"),
+        )
+        for fen, move, winner in cases:
+            with self.subTest(move=move):
+                result = REFERENCE.replay(request(fen, move))
+                self.assertTrue(result["accepted"])
+                self.assertEqual(result["terminal"]["primary_reason"], "HILL")
+                self.assertEqual(result["terminal"]["winner"], winner)
+                self.assertEqual(result["plies"][0]["san"][-1], "#")
+                self.assertEqual(result["plies"][0]["game_legal_move_count"], 0)
+
+    def test_every_goal_entry_attacked_for_both_colors_is_illegal(self):
+        cases = (
+            ("3r3k/8/8/8/8/2K5/8/8 w - - 0 1", "c3d4"),
+            ("4r2k/8/8/8/8/3K4/8/8 w - - 0 1", "d3e4"),
+            ("3r3k/8/8/8/2K5/8/8/8 w - - 0 1", "c4d5"),
+            ("4r2k/8/8/8/5K2/8/8/8 w - - 0 1", "f4e5"),
+            ("8/8/2k5/8/8/8/8/K2R4 b - - 0 1", "c6d5"),
+            ("8/8/3k4/8/8/8/8/K3R3 b - - 0 1", "d6e5"),
+            ("8/8/8/2k5/8/8/8/K2R4 b - - 0 1", "c5d4"),
+            ("8/8/8/5k2/8/8/8/K3R3 b - - 0 1", "f5e4"),
+        )
+        for fen, move in cases:
+            with self.subTest(move=move), self.assertRaises(
+                REFERENCE.ReferenceError
+            ) as caught:
+                REFERENCE.replay(request(fen, move))
+            self.assertEqual(caught.exception.code, "KREF_E_MOVE_ILLEGAL")
+
+    def test_non_king_on_goal_is_not_terminal(self):
+        result = REFERENCE.replay(
+            request("7k/8/8/8/8/8/2N5/K7 w - - 0 1", "c2d4")
+        )
+        self.assertFalse(result["terminal"]["terminal"])
+        self.assertEqual(result["plies"][0]["san"], "Nd4")
+
+    def test_loaded_goal_is_rejected_for_both_turns(self):
+        for turn in ("w", "b"):
+            with self.subTest(turn=turn), self.assertRaises(
+                REFERENCE.ReferenceError
+            ) as caught:
+                REFERENCE.replay(
+                    request(f"7k/8/8/8/3K4/8/8/8 {turn} - - 1 1")
+                )
+            self.assertEqual(caught.exception.code, "KREF_E_AMBIGUOUS_GOAL_ROOT")
+
+    def test_move_after_terminal_is_rejected(self):
+        with self.assertRaises(REFERENCE.ReferenceError) as caught:
+            REFERENCE.replay(
+                request(
+                    "7k/8/8/8/8/2K5/8/8 w - - 0 1",
+                    "c3d4",
+                    "h8h7",
+                )
+            )
+        self.assertEqual(caught.exception.code, "KREF_E_MOVE_AFTER_TERMINAL")
+
+    def test_fifty_move_root_is_rejected(self):
+        with self.assertRaises(REFERENCE.ReferenceError) as caught:
+            REFERENCE.replay(request("7k/8/8/8/8/2K5/8/8 w - - 100 1"))
+        self.assertEqual(caught.exception.code, "KREF_E_TERMINAL_ROOT")
+
+    def test_checkmate_and_hill_predicates_are_both_retained(self):
+        result = REFERENCE.replay(
+            request("2k2N2/5N2/8/8/8/2K5/8/1RR5 w - - 0 1", "c3d4")
+        )
+        terminal = result["terminal"]
+        self.assertEqual(terminal["predicates"], ("CHECKMATE", "HILL"))
+        self.assertEqual(terminal["primary_reason"], "CHECKMATE")
+        self.assertEqual(result["plies"][0]["san"], "Kd4#")
+
+    def test_hill_precedes_stalemate_and_fifty_move(self):
+        stalemate = REFERENCE.replay(
+            request("k1B5/8/2N5/8/8/2K5/8/8 w - - 0 1", "c3d4")
+        )
+        self.assertEqual(stalemate["terminal"]["predicates"], ("HILL", "STALEMATE"))
+        self.assertEqual(stalemate["terminal"]["primary_reason"], "HILL")
+
+        fifty = REFERENCE.replay(
+            request("7k/8/8/8/8/2K5/8/8 w - - 99 1", "c3d4")
+        )
+        self.assertEqual(fifty["terminal"]["predicates"], ("HILL", "FIFTY_MOVE"))
+        self.assertEqual(fifty["terminal"]["primary_reason"], "HILL")
+
+    def test_threefold_ends_an_honest_replay(self):
+        result = REFERENCE.replay(
+            request(
+                chess.STARTING_FEN,
+                "g1f3",
+                "g8f6",
+                "f3g1",
+                "f6g8",
+                "g1f3",
+                "g8f6",
+                "f3g1",
+                "f6g8",
+            )
+        )
+        self.assertEqual(result["terminal"]["predicates"], ("THREEFOLD",))
+        self.assertEqual(result["terminal"]["primary_reason"], "AUTOMATIC_DRAW")
+
+    def test_synthetic_fivefold_sets_both_repetition_predicates(self):
+        board = chess.Board()
+        for _ in range(4):
+            for token in ("g1f3", "g8f6", "f3g1", "f6g8"):
+                board.push_uci(token)
+        terminal = REFERENCE.terminal_status(
+            board, hill_transition=False, mover=chess.BLACK
+        )
+        self.assertEqual(terminal.predicates, ("THREEFOLD", "FIVEFOLD"))
+        self.assertEqual(terminal.primary_reason, "AUTOMATIC_DRAW")
+
+    def test_cli_consumes_utf8_json_and_emits_canonical_json(self):
+        payload = json.dumps(
+            request("7k/8/8/8/8/2K5/8/8 w - - 0 1", "c3d4")
+        ).encode("utf-8")
+        completed = subprocess.run(
+            [sys.executable, str(ROOT / "tools" / "koth_reference.py"), "replay"],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr.decode("utf-8"))
+        decoded = json.loads(completed.stdout.decode("utf-8"))
+        self.assertTrue(decoded["accepted"])
+        canonical = json.dumps(decoded, sort_keys=True, separators=(",", ":")) + "\n"
+        self.assertEqual(completed.stdout.decode("utf-8"), canonical)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/koth_reference.py
+++ b/tools/koth_reference.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Independent executable reference for KOTH_LICHESS_V1.
+
+This module deliberately depends on python-chess only for standard physical
+chess state and legal moves. KOTH trajectory and terminal semantics live here,
+not in python-chess's variant result helpers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Final, Iterable
+
+import chess
+
+
+INPUT_SCHEMA: Final = "koth-reference-input-v1"
+OUTPUT_SCHEMA: Final = "koth-reference-output-v1"
+PROFILE: Final = "KOTH_LICHESS_V1"
+REFERENCE_ID: Final = "koth-python-reference-v1"
+GOALS: Final = frozenset((chess.D4, chess.E4, chess.D5, chess.E5))
+PREDICATE_ORDER: Final = (
+    "CHECKMATE",
+    "HILL",
+    "STALEMATE",
+    "THREEFOLD",
+    "FIVEFOLD",
+    "FIFTY_MOVE",
+)
+
+
+class ReferenceError(Exception):
+    """Stable fail-closed input or trajectory error."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class TerminalStatus:
+    terminal: bool
+    predicates: tuple[str, ...]
+    primary_reason: str
+    winner: str | None
+    result: str
+
+
+def canonical_fen(board: chess.Board) -> str:
+    return board.fen(en_passant="fen")
+
+
+def sorted_legal_uci(board: chess.Board) -> list[str]:
+    return sorted(move.uci() for move in board.legal_moves)
+
+
+def legal_moves_sha256(moves: Iterable[str]) -> str:
+    payload = ("\n".join(moves) + "\n").encode("ascii")
+    return hashlib.sha256(payload).hexdigest().upper()
+
+
+def goal_occupants(board: chess.Board) -> tuple[str, ...]:
+    occupants: list[str] = []
+    for color, label in ((chess.WHITE, "white"), (chess.BLACK, "black")):
+        square = board.king(color)
+        if square in GOALS:
+            occupants.append(label)
+    return tuple(occupants)
+
+
+def terminal_status(
+    board: chess.Board,
+    *,
+    hill_transition: bool,
+    mover: chess.Color | None,
+) -> TerminalStatus:
+    present: set[str] = set()
+    if board.is_checkmate():
+        present.add("CHECKMATE")
+    if hill_transition:
+        present.add("HILL")
+    if board.is_stalemate():
+        present.add("STALEMATE")
+    if board.is_repetition(3):
+        present.add("THREEFOLD")
+    if board.is_repetition(5):
+        present.add("FIVEFOLD")
+    if board.halfmove_clock >= 100:
+        present.add("FIFTY_MOVE")
+
+    predicates = tuple(name for name in PREDICATE_ORDER if name in present)
+    if "CHECKMATE" in present:
+        primary = "CHECKMATE"
+        winner_color = not board.turn
+    elif "HILL" in present:
+        primary = "HILL"
+        winner_color = mover
+    elif "STALEMATE" in present:
+        primary = "STALEMATE"
+        winner_color = None
+    elif present.intersection(("THREEFOLD", "FIVEFOLD", "FIFTY_MOVE")):
+        primary = "AUTOMATIC_DRAW"
+        winner_color = None
+    else:
+        primary = "NONE"
+        winner_color = None
+
+    if winner_color is chess.WHITE:
+        winner, result = "white", "1-0"
+    elif winner_color is chess.BLACK:
+        winner, result = "black", "0-1"
+    else:
+        winner = None
+        result = "1/2-1/2" if primary in ("STALEMATE", "AUTOMATIC_DRAW") else "*"
+
+    return TerminalStatus(
+        terminal=primary != "NONE",
+        predicates=predicates,
+        primary_reason=primary,
+        winner=winner,
+        result=result,
+    )
+
+
+def checked_root(root_fen: str) -> chess.Board:
+    if not isinstance(root_fen, str) or len(root_fen.split()) != 6:
+        raise ReferenceError("KREF_E_FEN_FIELDS", "root_fen must contain six fields")
+    try:
+        board = chess.Board(root_fen, chess960=False)
+    except ValueError as exc:
+        raise ReferenceError("KREF_E_FEN_PARSE", str(exc)) from exc
+
+    if board.status() != chess.STATUS_VALID:
+        raise ReferenceError("KREF_E_FEN_INVALID", f"status={board.status()}")
+    if canonical_fen(board) != root_fen:
+        raise ReferenceError("KREF_E_FEN_NONCANONICAL", "root_fen does not round-trip exactly")
+
+    occupants = goal_occupants(board)
+    if occupants:
+        raise ReferenceError(
+            "KREF_E_AMBIGUOUS_GOAL_ROOT",
+            "goal occupancy lacks an authenticated predecessor transition",
+        )
+
+    status = terminal_status(board, hill_transition=False, mover=None)
+    if status.terminal:
+        raise ReferenceError(
+            "KREF_E_TERMINAL_ROOT",
+            f"already-terminal root: {status.primary_reason}",
+        )
+    return board
+
+
+def koth_san(standard_san: str, status: TerminalStatus) -> str:
+    if "CHECKMATE" in status.predicates or "HILL" in status.predicates:
+        if standard_san.endswith(("+", "#")):
+            standard_san = standard_san[:-1]
+        return standard_san + "#"
+    return standard_san
+
+
+def replay(request: dict[str, Any]) -> dict[str, Any]:
+    if request.get("schema") != INPUT_SCHEMA:
+        raise ReferenceError("KREF_E_SCHEMA", f"expected {INPUT_SCHEMA}")
+    if request.get("rule_profile") != PROFILE:
+        raise ReferenceError("KREF_E_PROFILE", f"expected {PROFILE}")
+
+    moves = request.get("moves")
+    if not isinstance(moves, list) or any(not isinstance(move, str) for move in moves):
+        raise ReferenceError("KREF_E_MOVES", "moves must be a JSON array of strings")
+
+    root_fen = request.get("root_fen")
+    board = checked_root(root_fen)
+    records: list[dict[str, Any]] = []
+    last_status = terminal_status(board, hill_transition=False, mover=None)
+
+    for index, token in enumerate(moves, start=1):
+        if last_status.terminal:
+            raise ReferenceError(
+                "KREF_E_MOVE_AFTER_TERMINAL",
+                f"move token follows terminal ply {index - 1}",
+            )
+        try:
+            move = chess.Move.from_uci(token)
+        except ValueError as exc:
+            raise ReferenceError("KREF_E_MOVE_PARSE", f"ply={index}") from exc
+        if move not in board.legal_moves:
+            raise ReferenceError("KREF_E_MOVE_ILLEGAL", f"ply={index} move={token}")
+
+        pre_fen = canonical_fen(board)
+        moving_piece = board.piece_at(move.from_square)
+        mover = board.turn
+        standard_san = board.san(move)
+        board.push(move)
+
+        hill_transition = bool(
+            moving_piece
+            and moving_piece.piece_type == chess.KING
+            and moving_piece.color == mover
+            and move.to_square in GOALS
+            and board.king(mover) == move.to_square
+        )
+        if len(goal_occupants(board)) > 1:
+            raise ReferenceError("KREF_E_INVALID_TRAJECTORY", f"ply={index}")
+
+        last_status = terminal_status(
+            board,
+            hill_transition=hill_transition,
+            mover=mover,
+        )
+        physical_moves = sorted_legal_uci(board)
+        records.append(
+            {
+                "ply": index,
+                "move": token,
+                "pre_fen": pre_fen,
+                "post_fen": canonical_fen(board),
+                "san": koth_san(standard_san, last_status),
+                "physical_legal_moves_sha256": legal_moves_sha256(physical_moves),
+                "physical_legal_move_count": len(physical_moves),
+                "game_legal_move_count": 0 if last_status.terminal else len(physical_moves),
+                "terminal": asdict(last_status),
+            }
+        )
+
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "reference_id": REFERENCE_ID,
+        "rule_profile": PROFILE,
+        "accepted": True,
+        "root_fen": root_fen,
+        "moves": moves,
+        "plies": records,
+        "final_fen": canonical_fen(board),
+        "terminal": asdict(last_status),
+    }
+
+
+def failure(exc: ReferenceError) -> dict[str, Any]:
+    return {
+        "schema": OUTPUT_SCHEMA,
+        "reference_id": REFERENCE_ID,
+        "rule_profile": PROFILE,
+        "accepted": False,
+        "error": {"code": exc.code, "detail": exc.detail},
+    }
+
+
+def identity() -> dict[str, Any]:
+    return {
+        "schema": "koth-reference-identity-v1",
+        "reference_id": REFERENCE_ID,
+        "rule_profile": PROFILE,
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "chess_version": chess.__version__,
+        "goal_squares": ["d4", "e4", "d5", "e5"],
+    }
+
+
+def read_request() -> dict[str, Any]:
+    try:
+        value = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReferenceError("KREF_E_JSON", "invalid UTF-8 JSON input") from exc
+    if not isinstance(value, dict):
+        raise ReferenceError("KREF_E_JSON_TYPE", "input must be a JSON object")
+    return value
+
+
+def emit(value: dict[str, Any]) -> None:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(payload + b"\n")
+    sys.stdout.buffer.flush()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("identity", "replay"))
+    args = parser.parse_args(argv)
+
+    if args.command == "identity":
+        emit(identity())
+        return 0
+
+    try:
+        emit(replay(read_request()))
+        return 0
+    except ReferenceError as exc:
+        emit(failure(exc))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/requirements.lock
+++ b/tools/reference/requirements.lock
@@ -1,0 +1,3 @@
+# Source archive: chess-1.11.2.tar.gz
+# License: GPL-3.0+
+chess==1.11.2 --hash=sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39


### PR DESCRIPTION
## Summary

- freeze the deterministic `KOTH_CLOCK_V1` boundary for certified local matches
- add an independent executable `KOTH_LICHESS_V1` replay reference
- pin the reference dependency by source archive SHA-256
- cover every goal square for both colors, attacked entries, loaded-goal rejection, terminal suffix rejection, repetition, and terminal precedence
- add public Windows CI without storing or downloading NNUE weights

## Why

Engine, reference, and referee agreement requires an executable comparator and exact clock semantics before engine behavior or search work can be certified. This change establishes that authority surface without changing the engine.

## Validation

- clean Python 3.12.0 virtual environment
- hashed `chess==1.11.2` installation
- `python -m py_compile tools/koth_reference.py tests/koth_reference_test.py`
- `python -m unittest -v tests/koth_reference_test.py` (11 tests)
- canonical UTF-8/LF CLI output check
- `git diff --check`

This pull request is engineering evidence only. It makes no Elo, engine-correctness, referee-certification, or release claim.
